### PR TITLE
Add duration_seconds field and debug logging

### DIFF
--- a/client/components/AudioPlayer.tsx
+++ b/client/components/AudioPlayer.tsx
@@ -24,6 +24,7 @@ export function AudioPlayer({
   onClose,
   databaseDuration,
 }: AudioPlayerProps) {
+  console.log("AudioPlayer databaseDuration:", databaseDuration);
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);

--- a/client/pages/Recordings.tsx
+++ b/client/pages/Recordings.tsx
@@ -197,6 +197,8 @@ export function Recordings() {
   };
 
   const handlePlay = (recording: RecordingHistory) => {
+    console.log("handlePlay recording:", recording);
+    console.log("duration_seconds:", recording.duration_seconds);
     if (recording.status === "completed" && recording.file_name) {
       setPlayingId(recording.id);
 

--- a/server/routes/recordings-db.ts
+++ b/server/routes/recordings-db.ts
@@ -104,7 +104,7 @@ export const getRecording: RequestHandler = async (req, res) => {
     const { id } = req.params;
 
     const query = `
-      SELECT 
+      SELECT
         id,
         cnic,
         start_time,
@@ -112,16 +112,20 @@ export const getRecording: RequestHandler = async (req, res) => {
         file_name,
         CREATED_ON as created_on,
         ip_address,
-        CASE 
-          WHEN end_time IS NOT NULL THEN TIMESTAMPDIFF(MINUTE, start_time, end_time)
+        CASE
+          WHEN end_time IS NOT NULL THEN TIMESTAMPDIFF(SECOND, start_time, end_time)
           ELSE NULL
         END as duration,
-        CASE 
+        CASE
+          WHEN end_time IS NOT NULL THEN TIMESTAMPDIFF(SECOND, start_time, end_time)
+          ELSE NULL
+        END as duration_seconds,
+        CASE
           WHEN end_time IS NOT NULL AND file_name IS NOT NULL THEN 'completed'
           WHEN start_time IS NOT NULL AND end_time IS NULL THEN 'in_progress'
           ELSE 'failed'
         END as status
-      FROM recording_history 
+      FROM recording_history
       WHERE id = ?
     `;
 

--- a/server/routes/recordings-db.ts
+++ b/server/routes/recordings-db.ts
@@ -45,7 +45,7 @@ export const getRecordings: RequestHandler = async (req, res) => {
 
     // Get paginated results
     const dataQuery = `
-      SELECT 
+      SELECT
     rh.id,
     rh.cnic,
     rh.start_time,
@@ -54,12 +54,17 @@ export const getRecordings: RequestHandler = async (req, res) => {
     rh.CREATED_ON AS created_on,
     rh.ip_address,
     COALESCE(dm.device_name, rh.ip_address) AS device_name,
-    CASE 
-        WHEN rh.end_time IS NOT NULL THEN 
+    CASE
+        WHEN rh.end_time IS NOT NULL THEN
             TIMESTAMPDIFF(SECOND, rh.start_time, rh.end_time)
         ELSE NULL
     END AS duration,
-    CASE 
+    CASE
+        WHEN rh.end_time IS NOT NULL THEN
+            TIMESTAMPDIFF(SECOND, rh.start_time, rh.end_time)
+        ELSE NULL
+    END AS duration_seconds,
+    CASE
         WHEN rh.end_time IS NOT NULL AND rh.file_name IS NOT NULL THEN 'completed'
         WHEN rh.start_time IS NOT NULL AND rh.end_time IS NULL THEN 'in_progress'
         ELSE 'failed'


### PR DESCRIPTION
This change adds a new duration_seconds field to recording queries and includes debug logging for troubleshooting.

Changes made:
- Added duration_seconds field to both getRecordings and getRecording queries in recordings-db.ts
- Changed duration calculation from TIMESTAMPDIFF(MINUTE) to TIMESTAMPDIFF(SECOND) in getRecording query
- Added console.log statements in AudioPlayer.tsx to log databaseDuration parameter
- Added console.log statements in Recordings.tsx to log recording object and duration_seconds in handlePlay function
- Minor formatting improvements (whitespace cleanup) in SQL queries

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/125630c9a7c54371a270355d525e717c/cosmos-space)

👀 [Preview Link](https://125630c9a7c54371a270355d525e717c-cosmos-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>125630c9a7c54371a270355d525e717c</projectId>-->
<!--<branchName>cosmos-space</branchName>-->