### PR TITLE
Add voice streams analytics with monthly and daily charts

### DIFF
--- a/client/components/BranchVoiceStreamsAnalytics.tsx
+++ b/client/components/BranchVoiceStreamsAnalytics.tsx
@@ -1,13 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { authFetch } from "@/lib/api";
-import {
-  RefreshCw,
-  Mic,
-  Calendar,
-  TrendingUp,
-  BarChart3,
-} from "lucide-react";
+import { RefreshCw, Mic, Calendar, TrendingUp, BarChart3 } from "lucide-react";
 import {
   BarChart,
   Bar,
@@ -116,7 +110,9 @@ export function BranchVoiceStreamsAnalytics() {
               </div>
               <div className="absolute -inset-1 bg-gradient-to-r from-blue-500/20 to-indigo-600/20 rounded-xl blur animate-pulse"></div>
             </div>
-            <span className="text-gray-600 font-medium">Loading voice stream analytics...</span>
+            <span className="text-gray-600 font-medium">
+              Loading voice stream analytics...
+            </span>
           </div>
         </div>
       </div>
@@ -133,7 +129,9 @@ export function BranchVoiceStreamsAnalytics() {
                 <Mic className="h-5 w-5 text-white" />
               </div>
               <div>
-                <h4 className="font-semibold text-red-800">Failed to load voice stream analytics</h4>
+                <h4 className="font-semibold text-red-800">
+                  Failed to load voice stream analytics
+                </h4>
                 <p className="text-red-600 text-sm">{error}</p>
               </div>
             </div>
@@ -154,9 +152,14 @@ export function BranchVoiceStreamsAnalytics() {
   }
 
   // Calculate growth percentage
-  const growthPercentage = data.previous_month_streams > 0
-    ? ((data.current_month_streams - data.previous_month_streams) / data.previous_month_streams) * 100
-    : data.current_month_streams > 0 ? 100 : 0;
+  const growthPercentage =
+    data.previous_month_streams > 0
+      ? ((data.current_month_streams - data.previous_month_streams) /
+          data.previous_month_streams) *
+        100
+      : data.current_month_streams > 0
+        ? 100
+        : 0;
 
   return (
     <div className="space-y-6">
@@ -187,8 +190,12 @@ export function BranchVoiceStreamsAnalytics() {
                 <Mic className="h-5 w-5 text-white" />
               </div>
               <div>
-                <p className="text-sm font-medium text-blue-700">Total Voice Streams</p>
-                <p className="text-2xl font-bold text-blue-900">{data.total_streams.toLocaleString()}</p>
+                <p className="text-sm font-medium text-blue-700">
+                  Total Voice Streams
+                </p>
+                <p className="text-2xl font-bold text-blue-900">
+                  {data.total_streams.toLocaleString()}
+                </p>
               </div>
             </div>
           </div>
@@ -203,8 +210,12 @@ export function BranchVoiceStreamsAnalytics() {
                 <Calendar className="h-5 w-5 text-white" />
               </div>
               <div>
-                <p className="text-sm font-medium text-emerald-700">This Month</p>
-                <p className="text-2xl font-bold text-emerald-900">{data.current_month_streams.toLocaleString()}</p>
+                <p className="text-sm font-medium text-emerald-700">
+                  This Month
+                </p>
+                <p className="text-2xl font-bold text-emerald-900">
+                  {data.current_month_streams.toLocaleString()}
+                </p>
               </div>
             </div>
           </div>
@@ -219,9 +230,14 @@ export function BranchVoiceStreamsAnalytics() {
                 <TrendingUp className="h-5 w-5 text-white" />
               </div>
               <div>
-                <p className="text-sm font-medium text-purple-700">Monthly Growth</p>
-                <p className={`text-2xl font-bold ${growthPercentage >= 0 ? 'text-purple-900' : 'text-red-600'}`}>
-                  {growthPercentage >= 0 ? '+' : ''}{growthPercentage.toFixed(1)}%
+                <p className="text-sm font-medium text-purple-700">
+                  Monthly Growth
+                </p>
+                <p
+                  className={`text-2xl font-bold ${growthPercentage >= 0 ? "text-purple-900" : "text-red-600"}`}
+                >
+                  {growthPercentage >= 0 ? "+" : ""}
+                  {growthPercentage.toFixed(1)}%
                 </p>
               </div>
             </div>
@@ -256,9 +272,19 @@ export function BranchVoiceStreamsAnalytics() {
                 margin={{ top: 10, right: 20, left: 10, bottom: 10 }}
               >
                 <defs>
-                  <linearGradient id="voiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
+                  <linearGradient
+                    id="voiceStreamGradient"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
                     <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
-                    <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
+                    <stop
+                      offset="100%"
+                      stopColor="#3b82f6"
+                      stopOpacity={0.05}
+                    />
                   </linearGradient>
                 </defs>
                 <CartesianGrid
@@ -271,17 +297,17 @@ export function BranchVoiceStreamsAnalytics() {
                   dataKey="formatted_month"
                   fontSize={9}
                   fontWeight={500}
-                  tick={{ fill: '#6b7280' }}
-                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tick={{ fill: "#6b7280" }}
+                  axisLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
+                  tickLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
                   interval="preserveStartEnd"
                 />
                 <YAxis
                   fontSize={9}
                   fontWeight={500}
-                  tick={{ fill: '#6b7280' }}
-                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tick={{ fill: "#6b7280" }}
+                  axisLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
+                  tickLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
                   tickFormatter={(value) => value.toLocaleString()}
                 />
                 <Tooltip content={<CustomTooltip />} />
@@ -301,16 +327,22 @@ export function BranchVoiceStreamsAnalytics() {
             <div className="bg-gray-50/70 rounded-lg p-2 text-center">
               <p className="text-xs text-gray-500 mb-1">Peak Month</p>
               <p className="text-sm font-semibold text-gray-900">
-                {data.monthly_data.reduce((max, curr) =>
-                  curr.voice_streams > max.voice_streams ? curr : max,
-                  data.monthly_data[0]
-                )?.formatted_month || '—'}
+                {data.monthly_data.reduce(
+                  (max, curr) =>
+                    curr.voice_streams > max.voice_streams ? curr : max,
+                  data.monthly_data[0],
+                )?.formatted_month || "—"}
               </p>
             </div>
             <div className="bg-gray-50/70 rounded-lg p-2 text-center">
               <p className="text-xs text-gray-500 mb-1">Average/Month</p>
               <p className="text-sm font-semibold text-gray-900">
-                {Math.round(data.monthly_data.reduce((sum, d) => sum + d.voice_streams, 0) / data.monthly_data.length).toLocaleString()}
+                {Math.round(
+                  data.monthly_data.reduce(
+                    (sum, d) => sum + d.voice_streams,
+                    0,
+                  ) / data.monthly_data.length,
+                ).toLocaleString()}
               </p>
             </div>
           </div>
@@ -327,7 +359,11 @@ export function BranchVoiceStreamsAnalytics() {
                 Voice Streams This Month
               </h3>
               <p className="text-gray-600 text-xs mt-1">
-                Daily activity for {new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+                Daily activity for{" "}
+                {new Date().toLocaleDateString("en-US", {
+                  month: "long",
+                  year: "numeric",
+                })}
               </p>
             </div>
           </div>
@@ -340,7 +376,13 @@ export function BranchVoiceStreamsAnalytics() {
                 margin={{ top: 10, right: 20, left: 10, bottom: 10 }}
               >
                 <defs>
-                  <linearGradient id="dailyVoiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
+                  <linearGradient
+                    id="dailyVoiceStreamGradient"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
                     <stop offset="0%" stopColor="#10b981" stopOpacity={0.9} />
                     <stop offset="100%" stopColor="#059669" stopOpacity={0.8} />
                   </linearGradient>
@@ -355,17 +397,17 @@ export function BranchVoiceStreamsAnalytics() {
                   dataKey="formatted_date"
                   fontSize={9}
                   fontWeight={500}
-                  tick={{ fill: '#6b7280' }}
-                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tick={{ fill: "#6b7280" }}
+                  axisLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
+                  tickLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
                   interval="preserveStartEnd"
                 />
                 <YAxis
                   fontSize={9}
                   fontWeight={500}
-                  tick={{ fill: '#6b7280' }}
-                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tick={{ fill: "#6b7280" }}
+                  axisLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
+                  tickLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
                   tickFormatter={(value) => value.toLocaleString()}
                 />
                 <Tooltip content={<CustomTooltip />} />
@@ -383,16 +425,20 @@ export function BranchVoiceStreamsAnalytics() {
             <div className="bg-gray-50/70 rounded-lg p-2 text-center">
               <p className="text-xs text-gray-500 mb-1">Peak Day</p>
               <p className="text-sm font-semibold text-gray-900">
-                {data.daily_current_month.reduce((max, curr) =>
-                  curr.voice_streams > max.voice_streams ? curr : max,
-                  data.daily_current_month[0]
-                )?.formatted_date || '—'}
+                {data.daily_current_month.reduce(
+                  (max, curr) =>
+                    curr.voice_streams > max.voice_streams ? curr : max,
+                  data.daily_current_month[0],
+                )?.formatted_date || "—"}
               </p>
             </div>
             <div className="bg-gray-50/70 rounded-lg p-2 text-center">
               <p className="text-xs text-gray-500 mb-1">Active Days</p>
               <p className="text-sm font-semibold text-gray-900">
-                {data.daily_current_month.filter(d => d.voice_streams > 0).length}
+                {
+                  data.daily_current_month.filter((d) => d.voice_streams > 0)
+                    .length
+                }
               </p>
             </div>
           </div>

--- a/client/components/BranchVoiceStreamsAnalytics.tsx
+++ b/client/components/BranchVoiceStreamsAnalytics.tsx
@@ -1,0 +1,315 @@
+import React, { useState, useEffect } from "react";
+import { useAuth } from "../contexts/AuthContext";
+import { authFetch } from "@/lib/api";
+import {
+  RefreshCw,
+  Mic,
+  Calendar,
+  TrendingUp,
+  BarChart3,
+} from "lucide-react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  Area,
+  AreaChart,
+} from "recharts";
+
+interface MonthlyVoiceStreamData {
+  month: string;
+  voice_streams: number;
+  formatted_month: string;
+}
+
+interface VoiceStreamStats {
+  total_streams: number;
+  current_month_streams: number;
+  previous_month_streams: number;
+  monthly_data: MonthlyVoiceStreamData[];
+}
+
+export function BranchVoiceStreamsAnalytics() {
+  const { user, isAdmin } = useAuth();
+  const [data, setData] = useState<VoiceStreamStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchVoiceStreamData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await authFetch("/api/analytics/voice-streams");
+      if (!response.ok) {
+        throw new Error("Failed to fetch voice stream data");
+      }
+
+      const result = await response.json();
+      setData(result);
+    } catch (err) {
+      console.error("Error fetching voice stream data:", err);
+      setError(err instanceof Error ? err.message : "Failed to load data");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isAdmin()) {
+      fetchVoiceStreamData();
+    }
+  }, [isAdmin]);
+
+  // Custom tooltip for charts
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white/95 backdrop-blur-sm border border-gray-200/50 rounded-xl shadow-xl p-4 min-w-[200px]">
+          <div className="flex items-center space-x-2 mb-2">
+            <div className="w-3 h-3 rounded-full bg-gradient-to-r from-blue-500 to-indigo-600" />
+            <p className="font-semibold text-gray-900 text-sm">{label}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-lg font-bold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+              {payload[0].value} voice streams
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (isAdmin()) {
+    return null; // Don't show for admin users
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
+          <div className="flex flex-col items-center justify-center py-12">
+            <div className="relative">
+              <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-indigo-600 rounded-xl flex items-center justify-center mb-4">
+                <RefreshCw className="h-6 w-6 animate-spin text-white" />
+              </div>
+              <div className="absolute -inset-1 bg-gradient-to-r from-blue-500/20 to-indigo-600/20 rounded-xl blur animate-pulse"></div>
+            </div>
+            <span className="text-gray-600 font-medium">Loading voice stream analytics...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
+          <div className="bg-gradient-to-br from-red-50 to-red-100/50 border border-red-200/50 rounded-xl p-6">
+            <div className="flex items-center space-x-3 mb-3">
+              <div className="p-2 bg-red-500 rounded-lg">
+                <Mic className="h-5 w-5 text-white" />
+              </div>
+              <div>
+                <h4 className="font-semibold text-red-800">Failed to load voice stream analytics</h4>
+                <p className="text-red-600 text-sm">{error}</p>
+              </div>
+            </div>
+            <button
+              onClick={fetchVoiceStreamData}
+              className="mt-2 px-4 py-2 bg-gradient-to-r from-red-500 to-red-600 text-white rounded-lg hover:from-red-600 hover:to-red-700 transition-all duration-200 font-medium shadow-md"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  // Calculate growth percentage
+  const growthPercentage = data.previous_month_streams > 0 
+    ? ((data.current_month_streams - data.previous_month_streams) / data.previous_month_streams) * 100
+    : data.current_month_streams > 0 ? 100 : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center space-x-3">
+          <div className="p-3 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-xl shadow-md">
+            <Mic className="h-7 w-7 text-white" />
+          </div>
+          <div>
+            <h2 className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
+              Voice Streams Analytics
+            </h2>
+            <p className="text-gray-600 text-sm mt-1">
+              {user?.branch_city || "Your branch"} voice recording streams
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* Total Voice Streams */}
+        <div className="bg-gradient-to-br from-blue-50 to-indigo-50/50 rounded-xl p-6 border border-blue-100/50">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-3 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg">
+                <Mic className="h-5 w-5 text-white" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-blue-700">Total Voice Streams</p>
+                <p className="text-2xl font-bold text-blue-900">{data.total_streams.toLocaleString()}</p>
+              </div>
+            </div>
+          </div>
+          <p className="text-xs text-blue-600">All time recordings</p>
+        </div>
+
+        {/* This Month */}
+        <div className="bg-gradient-to-br from-emerald-50 to-green-50/50 rounded-xl p-6 border border-emerald-100/50">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-3 bg-gradient-to-br from-emerald-500 to-green-600 rounded-lg">
+                <Calendar className="h-5 w-5 text-white" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-emerald-700">This Month</p>
+                <p className="text-2xl font-bold text-emerald-900">{data.current_month_streams.toLocaleString()}</p>
+              </div>
+            </div>
+          </div>
+          <p className="text-xs text-emerald-600">Current month recordings</p>
+        </div>
+
+        {/* Growth */}
+        <div className="bg-gradient-to-br from-purple-50 to-violet-50/50 rounded-xl p-6 border border-purple-100/50">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-3 bg-gradient-to-br from-purple-500 to-violet-600 rounded-lg">
+                <TrendingUp className="h-5 w-5 text-white" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-purple-700">Monthly Growth</p>
+                <p className={`text-2xl font-bold ${growthPercentage >= 0 ? 'text-purple-900' : 'text-red-600'}`}>
+                  {growthPercentage >= 0 ? '+' : ''}{growthPercentage.toFixed(1)}%
+                </p>
+              </div>
+            </div>
+          </div>
+          <p className="text-xs text-purple-600">vs. previous month</p>
+        </div>
+      </div>
+
+      {/* Monthly Chart */}
+      <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center space-x-4">
+            <div className="p-3 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-xl shadow-md">
+              <BarChart3 className="h-7 w-7 text-white" />
+            </div>
+            <div>
+              <h3 className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
+                Voice Streams per Month
+              </h3>
+              <p className="text-gray-600 text-sm mt-1">
+                Recording activity over the last 12 months
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Chart */}
+        <div className="h-80 bg-gradient-to-b from-gray-50/30 to-white/30 rounded-xl p-4 border border-gray-100/50">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={data.monthly_data}
+              margin={{ top: 20, right: 30, left: 20, bottom: 20 }}
+            >
+              <defs>
+                <linearGradient id="voiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
+                  <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid 
+                strokeDasharray="2 4" 
+                stroke="#e5e7eb" 
+                strokeOpacity={0.5}
+                vertical={false}
+              />
+              <XAxis 
+                dataKey="formatted_month" 
+                fontSize={11}
+                fontWeight={500}
+                tick={{ fill: '#6b7280' }}
+                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+              />
+              <YAxis 
+                fontSize={11}
+                fontWeight={500}
+                tick={{ fill: '#6b7280' }}
+                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                tickFormatter={(value) => value.toLocaleString()}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Area 
+                type="monotone" 
+                dataKey="voice_streams" 
+                stroke="#3b82f6"
+                strokeWidth={3}
+                fill="url(#voiceStreamGradient)"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Chart Footer */}
+        <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Peak Month</p>
+            <p className="font-semibold text-gray-900">
+              {data.monthly_data.reduce((max, curr) => 
+                curr.voice_streams > max.voice_streams ? curr : max, 
+                data.monthly_data[0]
+              )?.formatted_month || '—'}
+            </p>
+          </div>
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Peak Count</p>
+            <p className="font-semibold text-gray-900">
+              {Math.max(...data.monthly_data.map(d => d.voice_streams)).toLocaleString()}
+            </p>
+          </div>
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Average/Month</p>
+            <p className="font-semibold text-gray-900">
+              {Math.round(data.monthly_data.reduce((sum, d) => sum + d.voice_streams, 0) / data.monthly_data.length).toLocaleString()}
+            </p>
+          </div>
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Total Period</p>
+            <p className="font-semibold text-gray-900">12 Months</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/BranchVoiceStreamsAnalytics.tsx
+++ b/client/components/BranchVoiceStreamsAnalytics.tsx
@@ -28,11 +28,18 @@ interface MonthlyVoiceStreamData {
   formatted_month: string;
 }
 
+interface DailyVoiceStreamData {
+  date: string;
+  voice_streams: number;
+  formatted_date: string;
+}
+
 interface VoiceStreamStats {
   total_streams: number;
   current_month_streams: number;
   previous_month_streams: number;
   monthly_data: MonthlyVoiceStreamData[];
+  daily_current_month: DailyVoiceStreamData[];
 }
 
 export function BranchVoiceStreamsAnalytics() {

--- a/client/components/BranchVoiceStreamsAnalytics.tsx
+++ b/client/components/BranchVoiceStreamsAnalytics.tsx
@@ -230,193 +230,171 @@ export function BranchVoiceStreamsAnalytics() {
         </div>
       </div>
 
-      {/* Monthly Chart */}
-      <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
-        <div className="flex items-center justify-between mb-8">
-          <div className="flex items-center space-x-4">
-            <div className="p-3 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-xl shadow-md">
-              <BarChart3 className="h-7 w-7 text-white" />
+      {/* Charts Side by Side */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        {/* Monthly Chart */}
+        <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-6">
+          <div className="flex items-center space-x-3 mb-6">
+            <div className="p-2 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg shadow-md">
+              <BarChart3 className="h-5 w-5 text-white" />
             </div>
             <div>
-              <h3 className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
+              <h3 className="text-lg font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
                 Voice Streams per Month
               </h3>
-              <p className="text-gray-600 text-sm mt-1">
-                Recording activity over the last 12 months
+              <p className="text-gray-600 text-xs mt-1">
+                Last 12 months activity
+              </p>
+            </div>
+          </div>
+
+          {/* Chart */}
+          <div className="h-64 bg-gradient-to-b from-gray-50/30 to-white/30 rounded-lg p-3 border border-gray-100/50">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart
+                data={data.monthly_data}
+                margin={{ top: 10, right: 20, left: 10, bottom: 10 }}
+              >
+                <defs>
+                  <linearGradient id="voiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
+                    <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid
+                  strokeDasharray="2 4"
+                  stroke="#e5e7eb"
+                  strokeOpacity={0.5}
+                  vertical={false}
+                />
+                <XAxis
+                  dataKey="formatted_month"
+                  fontSize={9}
+                  fontWeight={500}
+                  tick={{ fill: '#6b7280' }}
+                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  fontSize={9}
+                  fontWeight={500}
+                  tick={{ fill: '#6b7280' }}
+                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tickFormatter={(value) => value.toLocaleString()}
+                />
+                <Tooltip content={<CustomTooltip />} />
+                <Area
+                  type="monotone"
+                  dataKey="voice_streams"
+                  stroke="#3b82f6"
+                  strokeWidth={2}
+                  fill="url(#voiceStreamGradient)"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* Chart Footer */}
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <div className="bg-gray-50/70 rounded-lg p-2 text-center">
+              <p className="text-xs text-gray-500 mb-1">Peak Month</p>
+              <p className="text-sm font-semibold text-gray-900">
+                {data.monthly_data.reduce((max, curr) =>
+                  curr.voice_streams > max.voice_streams ? curr : max,
+                  data.monthly_data[0]
+                )?.formatted_month || '—'}
+              </p>
+            </div>
+            <div className="bg-gray-50/70 rounded-lg p-2 text-center">
+              <p className="text-xs text-gray-500 mb-1">Average/Month</p>
+              <p className="text-sm font-semibold text-gray-900">
+                {Math.round(data.monthly_data.reduce((sum, d) => sum + d.voice_streams, 0) / data.monthly_data.length).toLocaleString()}
               </p>
             </div>
           </div>
         </div>
 
-        {/* Chart */}
-        <div className="h-80 bg-gradient-to-b from-gray-50/30 to-white/30 rounded-xl p-4 border border-gray-100/50">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart
-              data={data.monthly_data}
-              margin={{ top: 20, right: 30, left: 20, bottom: 20 }}
-            >
-              <defs>
-                <linearGradient id="voiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
-                  <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid
-                strokeDasharray="2 4"
-                stroke="#e5e7eb"
-                strokeOpacity={0.5}
-                vertical={false}
-              />
-              <XAxis
-                dataKey="formatted_month"
-                fontSize={11}
-                fontWeight={500}
-                tick={{ fill: '#6b7280' }}
-                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-              />
-              <YAxis
-                fontSize={11}
-                fontWeight={500}
-                tick={{ fill: '#6b7280' }}
-                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                tickFormatter={(value) => value.toLocaleString()}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Area
-                type="monotone"
-                dataKey="voice_streams"
-                stroke="#3b82f6"
-                strokeWidth={3}
-                fill="url(#voiceStreamGradient)"
-              />
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
-
-        {/* Chart Footer */}
-        <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Peak Month</p>
-            <p className="font-semibold text-gray-900">
-              {data.monthly_data.reduce((max, curr) =>
-                curr.voice_streams > max.voice_streams ? curr : max,
-                data.monthly_data[0]
-              )?.formatted_month || '—'}
-            </p>
-          </div>
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Peak Count</p>
-            <p className="font-semibold text-gray-900">
-              {Math.max(...data.monthly_data.map(d => d.voice_streams)).toLocaleString()}
-            </p>
-          </div>
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Average/Month</p>
-            <p className="font-semibold text-gray-900">
-              {Math.round(data.monthly_data.reduce((sum, d) => sum + d.voice_streams, 0) / data.monthly_data.length).toLocaleString()}
-            </p>
-          </div>
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Total Period</p>
-            <p className="font-semibold text-gray-900">12 Months</p>
-          </div>
-        </div>
-      </div>
-
-      {/* Daily Current Month Chart */}
-      <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
-        <div className="flex items-center justify-between mb-8">
-          <div className="flex items-center space-x-4">
-            <div className="p-3 bg-gradient-to-br from-emerald-500 to-green-600 rounded-xl shadow-md">
-              <Calendar className="h-7 w-7 text-white" />
+        {/* Daily Current Month Chart */}
+        <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-6">
+          <div className="flex items-center space-x-3 mb-6">
+            <div className="p-2 bg-gradient-to-br from-emerald-500 to-green-600 rounded-lg shadow-md">
+              <Calendar className="h-5 w-5 text-white" />
             </div>
             <div>
-              <h3 className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
+              <h3 className="text-lg font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
                 Voice Streams This Month
               </h3>
-              <p className="text-gray-600 text-sm mt-1">
-                Daily recording activity for {new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+              <p className="text-gray-600 text-xs mt-1">
+                Daily activity for {new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
               </p>
             </div>
           </div>
-        </div>
 
-        {/* Daily Chart */}
-        <div className="h-80 bg-gradient-to-b from-gray-50/30 to-white/30 rounded-xl p-4 border border-gray-100/50">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={data.daily_current_month}
-              margin={{ top: 20, right: 30, left: 20, bottom: 20 }}
-            >
-              <defs>
-                <linearGradient id="dailyVoiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#10b981" stopOpacity={0.9} />
-                  <stop offset="100%" stopColor="#059669" stopOpacity={0.8} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid
-                strokeDasharray="2 4"
-                stroke="#e5e7eb"
-                strokeOpacity={0.5}
-                vertical={false}
-              />
-              <XAxis
-                dataKey="formatted_date"
-                fontSize={10}
-                fontWeight={500}
-                tick={{ fill: '#6b7280' }}
-                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                interval="preserveStartEnd"
-              />
-              <YAxis
-                fontSize={11}
-                fontWeight={500}
-                tick={{ fill: '#6b7280' }}
-                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-                tickFormatter={(value) => value.toLocaleString()}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Bar
-                dataKey="voice_streams"
-                fill="url(#dailyVoiceStreamGradient)"
-                radius={[2, 2, 0, 0]}
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+          {/* Daily Chart */}
+          <div className="h-64 bg-gradient-to-b from-gray-50/30 to-white/30 rounded-lg p-3 border border-gray-100/50">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={data.daily_current_month}
+                margin={{ top: 10, right: 20, left: 10, bottom: 10 }}
+              >
+                <defs>
+                  <linearGradient id="dailyVoiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#10b981" stopOpacity={0.9} />
+                    <stop offset="100%" stopColor="#059669" stopOpacity={0.8} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid
+                  strokeDasharray="2 4"
+                  stroke="#e5e7eb"
+                  strokeOpacity={0.5}
+                  vertical={false}
+                />
+                <XAxis
+                  dataKey="formatted_date"
+                  fontSize={9}
+                  fontWeight={500}
+                  tick={{ fill: '#6b7280' }}
+                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  fontSize={9}
+                  fontWeight={500}
+                  tick={{ fill: '#6b7280' }}
+                  axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                  tickFormatter={(value) => value.toLocaleString()}
+                />
+                <Tooltip content={<CustomTooltip />} />
+                <Bar
+                  dataKey="voice_streams"
+                  fill="url(#dailyVoiceStreamGradient)"
+                  radius={[2, 2, 0, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
 
-        {/* Daily Chart Footer */}
-        <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Peak Day</p>
-            <p className="font-semibold text-gray-900">
-              {data.daily_current_month.reduce((max, curr) =>
-                curr.voice_streams > max.voice_streams ? curr : max,
-                data.daily_current_month[0]
-              )?.formatted_date || '—'}
-            </p>
-          </div>
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Peak Count</p>
-            <p className="font-semibold text-gray-900">
-              {Math.max(...data.daily_current_month.map(d => d.voice_streams)).toLocaleString()}
-            </p>
-          </div>
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Average/Day</p>
-            <p className="font-semibold text-gray-900">
-              {Math.round(data.daily_current_month.reduce((sum, d) => sum + d.voice_streams, 0) / data.daily_current_month.length).toLocaleString()}
-            </p>
-          </div>
-          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
-            <p className="text-xs text-gray-500 mb-1">Active Days</p>
-            <p className="font-semibold text-gray-900">
-              {data.daily_current_month.filter(d => d.voice_streams > 0).length}
-            </p>
+          {/* Daily Chart Footer */}
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <div className="bg-gray-50/70 rounded-lg p-2 text-center">
+              <p className="text-xs text-gray-500 mb-1">Peak Day</p>
+              <p className="text-sm font-semibold text-gray-900">
+                {data.daily_current_month.reduce((max, curr) =>
+                  curr.voice_streams > max.voice_streams ? curr : max,
+                  data.daily_current_month[0]
+                )?.formatted_date || '—'}
+              </p>
+            </div>
+            <div className="bg-gray-50/70 rounded-lg p-2 text-center">
+              <p className="text-xs text-gray-500 mb-1">Active Days</p>
+              <p className="text-sm font-semibold text-gray-900">
+                {data.daily_current_month.filter(d => d.voice_streams > 0).length}
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/client/components/BranchVoiceStreamsAnalytics.tsx
+++ b/client/components/BranchVoiceStreamsAnalytics.tsx
@@ -324,6 +324,102 @@ export function BranchVoiceStreamsAnalytics() {
           </div>
         </div>
       </div>
+
+      {/* Daily Current Month Chart */}
+      <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center space-x-4">
+            <div className="p-3 bg-gradient-to-br from-emerald-500 to-green-600 rounded-xl shadow-md">
+              <Calendar className="h-7 w-7 text-white" />
+            </div>
+            <div>
+              <h3 className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
+                Voice Streams This Month
+              </h3>
+              <p className="text-gray-600 text-sm mt-1">
+                Daily recording activity for {new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Daily Chart */}
+        <div className="h-80 bg-gradient-to-b from-gray-50/30 to-white/30 rounded-xl p-4 border border-gray-100/50">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={data.daily_current_month}
+              margin={{ top: 20, right: 30, left: 20, bottom: 20 }}
+            >
+              <defs>
+                <linearGradient id="dailyVoiceStreamGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#10b981" stopOpacity={0.9} />
+                  <stop offset="100%" stopColor="#059669" stopOpacity={0.8} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid
+                strokeDasharray="2 4"
+                stroke="#e5e7eb"
+                strokeOpacity={0.5}
+                vertical={false}
+              />
+              <XAxis
+                dataKey="formatted_date"
+                fontSize={10}
+                fontWeight={500}
+                tick={{ fill: '#6b7280' }}
+                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                fontSize={11}
+                fontWeight={500}
+                tick={{ fill: '#6b7280' }}
+                axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+                tickFormatter={(value) => value.toLocaleString()}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Bar
+                dataKey="voice_streams"
+                fill="url(#dailyVoiceStreamGradient)"
+                radius={[2, 2, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Daily Chart Footer */}
+        <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Peak Day</p>
+            <p className="font-semibold text-gray-900">
+              {data.daily_current_month.reduce((max, curr) =>
+                curr.voice_streams > max.voice_streams ? curr : max,
+                data.daily_current_month[0]
+              )?.formatted_date || '—'}
+            </p>
+          </div>
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Peak Count</p>
+            <p className="font-semibold text-gray-900">
+              {Math.max(...data.daily_current_month.map(d => d.voice_streams)).toLocaleString()}
+            </p>
+          </div>
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Average/Day</p>
+            <p className="font-semibold text-gray-900">
+              {Math.round(data.daily_current_month.reduce((sum, d) => sum + d.voice_streams, 0) / data.daily_current_month.length).toLocaleString()}
+            </p>
+          </div>
+          <div className="bg-gray-50/70 rounded-lg p-3 text-center">
+            <p className="text-xs text-gray-500 mb-1">Active Days</p>
+            <p className="font-semibold text-gray-900">
+              {data.daily_current_month.filter(d => d.voice_streams > 0).length}
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/components/BranchVoiceStreamsAnalytics.tsx
+++ b/client/components/BranchVoiceStreamsAnalytics.tsx
@@ -48,7 +48,14 @@ export function BranchVoiceStreamsAnalytics() {
 
       const response = await authFetch("/api/analytics/voice-streams");
       if (!response.ok) {
-        throw new Error("Failed to fetch voice stream data");
+        let errorMessage = "Failed to fetch voice stream data";
+        try {
+          const errorResponse = await response.json();
+          errorMessage = errorResponse.error || errorMessage;
+        } catch (e) {
+          errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+        }
+        throw new Error(errorMessage);
       }
 
       const result = await response.json();
@@ -140,7 +147,7 @@ export function BranchVoiceStreamsAnalytics() {
   }
 
   // Calculate growth percentage
-  const growthPercentage = data.previous_month_streams > 0 
+  const growthPercentage = data.previous_month_streams > 0
     ? ((data.current_month_streams - data.previous_month_streams) / data.previous_month_streams) * 100
     : data.current_month_streams > 0 ? 100 : 0;
 
@@ -247,21 +254,21 @@ export function BranchVoiceStreamsAnalytics() {
                   <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
                 </linearGradient>
               </defs>
-              <CartesianGrid 
-                strokeDasharray="2 4" 
-                stroke="#e5e7eb" 
+              <CartesianGrid
+                strokeDasharray="2 4"
+                stroke="#e5e7eb"
                 strokeOpacity={0.5}
                 vertical={false}
               />
-              <XAxis 
-                dataKey="formatted_month" 
+              <XAxis
+                dataKey="formatted_month"
                 fontSize={11}
                 fontWeight={500}
                 tick={{ fill: '#6b7280' }}
                 axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
                 tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
               />
-              <YAxis 
+              <YAxis
                 fontSize={11}
                 fontWeight={500}
                 tick={{ fill: '#6b7280' }}
@@ -270,9 +277,9 @@ export function BranchVoiceStreamsAnalytics() {
                 tickFormatter={(value) => value.toLocaleString()}
               />
               <Tooltip content={<CustomTooltip />} />
-              <Area 
-                type="monotone" 
-                dataKey="voice_streams" 
+              <Area
+                type="monotone"
+                dataKey="voice_streams"
                 stroke="#3b82f6"
                 strokeWidth={3}
                 fill="url(#voiceStreamGradient)"
@@ -286,8 +293,8 @@ export function BranchVoiceStreamsAnalytics() {
           <div className="bg-gray-50/70 rounded-lg p-3 text-center">
             <p className="text-xs text-gray-500 mb-1">Peak Month</p>
             <p className="font-semibold text-gray-900">
-              {data.monthly_data.reduce((max, curr) => 
-                curr.voice_streams > max.voice_streams ? curr : max, 
+              {data.monthly_data.reduce((max, curr) =>
+                curr.voice_streams > max.voice_streams ? curr : max,
                 data.monthly_data[0]
               )?.formatted_month || '—'}
             </p>

--- a/client/components/ComplaintsStyleAnalytics.tsx
+++ b/client/components/ComplaintsStyleAnalytics.tsx
@@ -116,89 +116,91 @@ export function ComplaintsStyleAnalytics() {
             </h3>
           </div>
 
-        {dashboardData.loading ? (
-          <div className="flex items-center justify-center py-8">
-            <RefreshCw className="h-5 w-5 animate-spin text-blue-600 mr-2" />
-            <span className="text-gray-600">Loading conversation data...</span>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {/* Total Conversations */}
-            <div className="bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-blue-600 text-sm font-medium">
-                    Total Conversations
-                  </p>
-                  <p className="text-3xl font-bold text-blue-900">
-                    {dashboardData.conversations?.totalStats
-                      ?.totalConversations || "—"}
-                  </p>
-                </div>
-                <div className="p-3 bg-blue-200 rounded-lg">
-                  <MessageSquare className="h-6 w-6 text-blue-700" />
-                </div>
-              </div>
-              <div className="mt-3 text-xs text-blue-600">
-                {dashboardData.conversations
-                  ? "All time conversations recorded"
-                  : "Loading conversation data..."}
-              </div>
+          {dashboardData.loading ? (
+            <div className="flex items-center justify-center py-8">
+              <RefreshCw className="h-5 w-5 animate-spin text-blue-600 mr-2" />
+              <span className="text-gray-600">
+                Loading conversation data...
+              </span>
             </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {/* Total Conversations */}
+              <div className="bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-blue-600 text-sm font-medium">
+                      Total Conversations
+                    </p>
+                    <p className="text-3xl font-bold text-blue-900">
+                      {dashboardData.conversations?.totalStats
+                        ?.totalConversations || "—"}
+                    </p>
+                  </div>
+                  <div className="p-3 bg-blue-200 rounded-lg">
+                    <MessageSquare className="h-6 w-6 text-blue-700" />
+                  </div>
+                </div>
+                <div className="mt-3 text-xs text-blue-600">
+                  {dashboardData.conversations
+                    ? "All time conversations recorded"
+                    : "Loading conversation data..."}
+                </div>
+              </div>
 
-            {/* Conversations This Month */}
-            <div className="bg-gradient-to-r from-green-50 to-green-100 rounded-lg p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-green-600 text-sm font-medium">
-                    This Month
-                  </p>
-                  <p className="text-3xl font-bold text-green-900">
-                    {dashboardData.conversations
-                      ? dashboardData.conversations.totalStats
-                          ?.todayConversations ||
-                        Math.round(
-                          (dashboardData.conversations.totalStats
-                            ?.totalConversations || 0) * 0.3,
-                        )
-                      : "—"}
-                  </p>
+              {/* Conversations This Month */}
+              <div className="bg-gradient-to-r from-green-50 to-green-100 rounded-lg p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-green-600 text-sm font-medium">
+                      This Month
+                    </p>
+                    <p className="text-3xl font-bold text-green-900">
+                      {dashboardData.conversations
+                        ? dashboardData.conversations.totalStats
+                            ?.todayConversations ||
+                          Math.round(
+                            (dashboardData.conversations.totalStats
+                              ?.totalConversations || 0) * 0.3,
+                          )
+                        : "—"}
+                    </p>
+                  </div>
+                  <div className="p-3 bg-green-200 rounded-lg">
+                    <Calendar className="h-6 w-6 text-green-700" />
+                  </div>
                 </div>
-                <div className="p-3 bg-green-200 rounded-lg">
-                  <Calendar className="h-6 w-6 text-green-700" />
+                <div className="mt-3 text-xs text-green-600">
+                  {dashboardData.conversations
+                    ? "Conversations in current month"
+                    : "Loading monthly data..."}
                 </div>
               </div>
-              <div className="mt-3 text-xs text-green-600">
-                {dashboardData.conversations
-                  ? "Conversations in current month"
-                  : "Loading monthly data..."}
-              </div>
-            </div>
 
-            {/* Unique CNIC This Month */}
-            <div className="bg-gradient-to-r from-purple-50 to-purple-100 rounded-lg p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-purple-600 text-sm font-medium">
-                    Unique CNIC
-                  </p>
-                  <p className="text-3xl font-bold text-purple-900">
-                    {dashboardData.conversations?.totalStats?.uniqueCustomers ||
-                      "—"}
-                  </p>
+              {/* Unique CNIC This Month */}
+              <div className="bg-gradient-to-r from-purple-50 to-purple-100 rounded-lg p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-purple-600 text-sm font-medium">
+                      Unique CNIC
+                    </p>
+                    <p className="text-3xl font-bold text-purple-900">
+                      {dashboardData.conversations?.totalStats
+                        ?.uniqueCustomers || "—"}
+                    </p>
+                  </div>
+                  <div className="p-3 bg-purple-200 rounded-lg">
+                    <Users className="h-6 w-6 text-purple-700" />
+                  </div>
                 </div>
-                <div className="p-3 bg-purple-200 rounded-lg">
-                  <Users className="h-6 w-6 text-purple-700" />
+                <div className="mt-3 text-xs text-purple-600">
+                  {dashboardData.conversations
+                    ? "Unique customers this month"
+                    : "Loading unique customer data..."}
                 </div>
-              </div>
-              <div className="mt-3 text-xs text-purple-600">
-                {dashboardData.conversations
-                  ? "Unique customers this month"
-                  : "Loading unique customer data..."}
               </div>
             </div>
-          </div>
-        )}
+          )}
 
           {/* Error state */}
           {dashboardData.error && (

--- a/client/components/ComplaintsStyleAnalytics.tsx
+++ b/client/components/ComplaintsStyleAnalytics.tsx
@@ -84,26 +84,27 @@ export function ComplaintsStyleAnalytics() {
 
   return (
     <div className="space-y-6">
-      {/* Analytics Header */}
-      <div className="mb-6">
-        <div className="flex items-center space-x-3">
-          <div className="p-2 bg-purple-100 rounded-lg">
-            <BarChart3 className="h-6 w-6 text-purple-600" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">
-              {isAdmin()
-                ? "Analytics Dashboard"
-                : `${user?.branch_city || "Branch"} Analytics`}
-            </h1>
-            <p className="text-gray-600">
-              {isAdmin()
-                ? "Comprehensive analytics across all branches"
-                : "Analytics and insights for your branch"}
-            </p>
+      {/* Branch Voice Streams Analytics for Non-Admin Users */}
+      {!isAdmin() && <BranchVoiceStreamsAnalytics />}
+
+      {/* General Analytics Header for Admin Users */}
+      {isAdmin() && (
+        <div className="mb-6">
+          <div className="flex items-center space-x-3">
+            <div className="p-2 bg-purple-100 rounded-lg">
+              <BarChart3 className="h-6 w-6 text-purple-600" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">
+                Analytics Dashboard
+              </h1>
+              <p className="text-gray-600">
+                Comprehensive analytics across all branches
+              </p>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* Conversation Analytics Section */}
       <div className="bg-white rounded-lg shadow p-6 mb-8">

--- a/client/components/ComplaintsStyleAnalytics.tsx
+++ b/client/components/ComplaintsStyleAnalytics.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { authFetch } from "@/lib/api";
 import { InteractiveBranchChart } from "./InteractiveBranchChart";
+import { BranchVoiceStreamsAnalytics } from "./BranchVoiceStreamsAnalytics";
 import {
   RefreshCw,
   MessageSquare,

--- a/client/components/ComplaintsStyleAnalytics.tsx
+++ b/client/components/ComplaintsStyleAnalytics.tsx
@@ -200,19 +200,20 @@ export function ComplaintsStyleAnalytics() {
           </div>
         )}
 
-        {/* Error state */}
-        {dashboardData.error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mt-4">
-            <p className="text-red-600">Error: {dashboardData.error}</p>
-            <button
-              onClick={fetchDashboardAnalytics}
-              className="mt-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-            >
-              Retry
-            </button>
-          </div>
-        )}
-      </div>
+          {/* Error state */}
+          {dashboardData.error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4 mt-4">
+              <p className="text-red-600">Error: {dashboardData.error}</p>
+              <button
+                onClick={fetchDashboardAnalytics}
+                className="mt-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Interactive Branch Chart - Admin Only */}
       {isAdmin() && <InteractiveBranchChart />}

--- a/client/components/ComplaintsStyleAnalytics.tsx
+++ b/client/components/ComplaintsStyleAnalytics.tsx
@@ -106,16 +106,15 @@ export function ComplaintsStyleAnalytics() {
         </div>
       )}
 
-      {/* Conversation Analytics Section */}
-      <div className="bg-white rounded-lg shadow p-6 mb-8">
-        <div className="flex items-center space-x-2 mb-6">
-          <Users className="h-5 w-5 text-blue-600" />
-          <h3 className="text-lg font-semibold text-gray-900">
-            {isAdmin()
-              ? "Conversation Analytics"
-              : `${user?.branch_city || "Branch"} Conversation Analytics`}
-          </h3>
-        </div>
+      {/* Conversation Analytics Section - Admin Only */}
+      {isAdmin() && (
+        <div className="bg-white rounded-lg shadow p-6 mb-8">
+          <div className="flex items-center space-x-2 mb-6">
+            <Users className="h-5 w-5 text-blue-600" />
+            <h3 className="text-lg font-semibold text-gray-900">
+              Conversation Analytics
+            </h3>
+          </div>
 
         {dashboardData.loading ? (
           <div className="flex items-center justify-center py-8">

--- a/client/components/ComplaintsStyleAnalytics.tsx
+++ b/client/components/ComplaintsStyleAnalytics.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { authFetch } from "@/lib/api";
+import { InteractiveBranchChart } from "./InteractiveBranchChart";
 import {
   RefreshCw,
   MessageSquare,

--- a/client/components/ComplaintsStyleAnalytics.tsx
+++ b/client/components/ComplaintsStyleAnalytics.tsx
@@ -212,6 +212,9 @@ export function ComplaintsStyleAnalytics() {
           </div>
         )}
       </div>
+
+      {/* Interactive Branch Chart - Admin Only */}
+      {isAdmin() && <InteractiveBranchChart />}
     </div>
   );
 }

--- a/client/components/ExactDashboard.tsx
+++ b/client/components/ExactDashboard.tsx
@@ -499,15 +499,15 @@ export function ExactDashboard() {
   const currentRecordings = filteredRecordings.slice(startIndex, endIndex);
 
   return (
-    <div className="h-screen bg-gray-50 overflow-hidden">
+    <div className="min-h-screen bg-gray-50">
       <Header />
 
       {/* Navigation */}
       <AdminNavigation />
 
-      <div className="flex h-full">
+      <div className="flex min-h-0">
         {/* Main Content */}
-        <div className="flex-1 flex flex-col">
+        <div className="flex-1 flex flex-col min-h-0">
           <div
             className="flex-1 px-4 py-3 overflow-y-auto"
             style={{ padding: "12px 16px 3px" }}

--- a/client/components/ExactDashboard.tsx
+++ b/client/components/ExactDashboard.tsx
@@ -111,7 +111,8 @@ const fetchRecordings = async (
 const fetchHeartbeats = async (retries = 2): Promise<HeartbeatRecord[]> => {
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    // Increase timeout to 30 seconds for heartbeats
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
 
     const response = await authFetch("/api/heartbeats", {
       signal: controller.signal,
@@ -120,7 +121,8 @@ const fetchHeartbeats = async (retries = 2): Promise<HeartbeatRecord[]> => {
     clearTimeout(timeoutId);
 
     if (response.ok) {
-      return await response.json();
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
     } else {
       let errorText = "";
       try {
@@ -135,21 +137,24 @@ const fetchHeartbeats = async (retries = 2): Promise<HeartbeatRecord[]> => {
   } catch (error) {
     console.error("Error fetching heartbeats:", error);
     if (error.name === "AbortError") {
-      console.error("Request timed out after 10 seconds");
+      console.error("Heartbeat request timed out after 30 seconds");
     }
 
-    // Retry logic for development
+    // Only retry on network errors, not on timeouts
     if (
       retries > 0 &&
+      error.name !== "AbortError" &&
       (error.name === "TypeError" || error.message?.includes("Failed to fetch"))
     ) {
       console.log(
         `Retrying heartbeats fetch, ${retries} attempts remaining...`,
       );
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       return fetchHeartbeats(retries - 1);
     }
 
+    // Return empty array instead of throwing on timeout/error
+    console.warn("Heartbeats fetch failed, returning empty array");
     return [];
   }
 };

--- a/client/components/ExactDashboard.tsx
+++ b/client/components/ExactDashboard.tsx
@@ -231,10 +231,15 @@ export function ExactDashboard() {
     setIsRefreshing(true);
     try {
       const heartbeats = await fetchHeartbeats();
-      setDevices(heartbeats);
+      // Ensure heartbeats is an array
+      const validHeartbeats = Array.isArray(heartbeats) ? heartbeats : [];
+      setDevices(validHeartbeats);
       setLastUpdate(new Date());
     } catch (error) {
       console.error("Failed to load devices:", error);
+      // Set empty array on error to prevent crashes
+      setDevices([]);
+      setLastUpdate(new Date());
     } finally {
       setIsRefreshing(false);
     }

--- a/client/components/ExactDashboard.tsx
+++ b/client/components/ExactDashboard.tsx
@@ -301,12 +301,13 @@ export function ExactDashboard() {
     }
   }, [activeTab]);
 
-  // Device status counts
-  const onlineCount = devices.filter((d) => d.status === "online").length;
-  const problematicCount = devices.filter(
+  // Device status counts with safety checks
+  const safeDevices = Array.isArray(devices) ? devices : [];
+  const onlineCount = safeDevices.filter((d) => d.status === "online").length;
+  const problematicCount = safeDevices.filter(
     (d) => d.status === "problematic",
   ).length;
-  const offlineCount = devices.filter((d) => d.status === "offline").length;
+  const offlineCount = safeDevices.filter((d) => d.status === "offline").length;
 
   useEffect(() => {
     let filtered = recordings;

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -1,0 +1,366 @@
+import React, { useState, useEffect } from "react";
+import { authFetch } from "@/lib/api";
+import { useAuth } from "../contexts/AuthContext";
+import {
+  RefreshCw,
+  ChevronLeft,
+  BarChart3,
+  Building2,
+  Calendar,
+} from "lucide-react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+
+interface BranchMonthlyData {
+  branch_id: string;
+  branch_name: string;
+  branch_city: string;
+  month: string;
+  count: number;
+}
+
+interface ChartData {
+  name: string;
+  conversations: number;
+  branch_id?: string;
+  isOthers?: boolean;
+  details?: BranchMonthlyData[];
+}
+
+interface DrilldownData {
+  name: string;
+  conversations: number;
+  month: string;
+}
+
+export function InteractiveBranchChart() {
+  const { isAdmin } = useAuth();
+  const [rawData, setRawData] = useState<BranchMonthlyData[]>([]);
+  const [chartData, setChartData] = useState<ChartData[]>([]);
+  const [drilldownData, setDrilldownData] = useState<DrilldownData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedMonth, setSelectedMonth] = useState<string>("");
+  const [isDrilldown, setIsDrilldown] = useState(false);
+  const [drilldownTitle, setDrilldownTitle] = useState("");
+
+  // Get available months from data
+  const getAvailableMonths = () => {
+    const months = [...new Set(rawData.map(item => item.month))].sort().reverse();
+    return months;
+  };
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await authFetch("/api/analytics/conversations/branch-monthly");
+      if (!response.ok) {
+        throw new Error("Failed to fetch branch monthly data");
+      }
+
+      const data: BranchMonthlyData[] = await response.json();
+      setRawData(data);
+
+      // Set default month to the latest available
+      const availableMonths = [...new Set(data.map(item => item.month))].sort().reverse();
+      if (availableMonths.length > 0 && !selectedMonth) {
+        setSelectedMonth(availableMonths[0]);
+      }
+    } catch (err) {
+      console.error("Error fetching branch monthly data:", err);
+      setError(err instanceof Error ? err.message : "Failed to load data");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Process data for chart display
+  const processChartData = () => {
+    if (!selectedMonth || rawData.length === 0) return;
+
+    // Filter data for selected month
+    const monthData = rawData.filter(item => item.month === selectedMonth);
+
+    // Group by branch and sum conversations
+    const branchTotals = monthData.reduce((acc, item) => {
+      const key = item.branch_name;
+      if (!acc[key]) {
+        acc[key] = {
+          name: item.branch_name,
+          conversations: 0,
+          branch_id: item.branch_id,
+          details: []
+        };
+      }
+      acc[key].conversations += item.count;
+      acc[key].details.push(item);
+      return acc;
+    }, {} as Record<string, ChartData>);
+
+    // Sort by conversations count
+    const sortedBranches = Object.values(branchTotals).sort((a, b) => b.conversations - a.conversations);
+
+    // Take top 20 and group others
+    const top20 = sortedBranches.slice(0, 20);
+    const others = sortedBranches.slice(20);
+
+    const chartData: ChartData[] = [...top20];
+
+    // Add "Others" group if there are more than 20 branches
+    if (others.length > 0) {
+      const othersTotal = others.reduce((sum, branch) => sum + branch.conversations, 0);
+      chartData.push({
+        name: "Others",
+        conversations: othersTotal,
+        isOthers: true,
+        details: others.flatMap(branch => branch.details || [])
+      });
+    }
+
+    setChartData(chartData);
+  };
+
+  // Handle bar click for drilldown
+  const handleBarClick = (data: ChartData) => {
+    if (data.isOthers) {
+      // Show breakdown of "Others" branches
+      const othersBreakdown = rawData
+        .filter(item => item.month === selectedMonth)
+        .reduce((acc, item) => {
+          const existing = acc.find(x => x.name === item.branch_name);
+          if (existing) {
+            existing.conversations += item.count;
+          } else {
+            acc.push({
+              name: item.branch_name,
+              conversations: item.count,
+              month: item.month
+            });
+          }
+          return acc;
+        }, [] as DrilldownData[])
+        .filter(item => !chartData.slice(0, 20).find(c => c.name === item.name))
+        .sort((a, b) => b.conversations - a.conversations);
+
+      setDrilldownData(othersBreakdown);
+      setDrilldownTitle(`"Others" Branches - ${selectedMonth}`);
+      setIsDrilldown(true);
+    } else {
+      // Show monthly breakdown for specific branch
+      const branchMonthly = rawData
+        .filter(item => item.branch_name === data.name)
+        .map(item => ({
+          name: item.month,
+          conversations: item.count,
+          month: item.month
+        }))
+        .sort((a, b) => b.month.localeCompare(a.month));
+
+      setDrilldownData(branchMonthly);
+      setDrilldownTitle(`${data.name} - Monthly Breakdown`);
+      setIsDrilldown(true);
+    }
+  };
+
+  // Custom tooltip
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3">
+          <p className="font-medium text-gray-900">{`${label}`}</p>
+          <p className="text-blue-600">
+            {`Conversations: ${payload[0].value.toLocaleString()}`}
+          </p>
+          <p className="text-xs text-gray-500 mt-1">Click to drill down</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  useEffect(() => {
+    if (isAdmin()) {
+      fetchData();
+    }
+  }, [isAdmin]);
+
+  useEffect(() => {
+    processChartData();
+  }, [rawData, selectedMonth]);
+
+  if (!isAdmin()) {
+    return null;
+  }
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="flex items-center justify-center py-8">
+          <RefreshCw className="h-5 w-5 animate-spin text-blue-600 mr-2" />
+          <span className="text-gray-600">Loading branch analytics...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-red-600">Error: {error}</p>
+          <button
+            onClick={fetchData}
+            className="mt-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const availableMonths = getAvailableMonths();
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center space-x-3">
+          {isDrilldown && (
+            <button
+              onClick={() => setIsDrilldown(false)}
+              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              <ChevronLeft className="h-5 w-5 text-gray-600" />
+            </button>
+          )}
+          <div className="p-2 bg-blue-100 rounded-lg">
+            <BarChart3 className="h-6 w-6 text-blue-600" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">
+              {isDrilldown ? drilldownTitle : "Conversations by Branch"}
+            </h3>
+            <p className="text-gray-600">
+              {isDrilldown 
+                ? "Detailed breakdown view" 
+                : "Interactive chart showing top 20 branches + others"}
+            </p>
+          </div>
+        </div>
+
+        {!isDrilldown && (
+          <div className="flex items-center space-x-2">
+            <Calendar className="h-4 w-4 text-gray-500" />
+            <select
+              value={selectedMonth}
+              onChange={(e) => setSelectedMonth(e.target.value)}
+              className="border border-gray-200 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {availableMonths.map(month => (
+                <option key={month} value={month}>
+                  {new Date(month + '-01').toLocaleDateString('en-US', { 
+                    year: 'numeric', 
+                    month: 'long' 
+                  })}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {/* Chart */}
+      <div className="h-96">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={isDrilldown ? drilldownData : chartData}
+            margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis 
+              dataKey="name" 
+              angle={-45}
+              textAnchor="end"
+              height={80}
+              fontSize={12}
+              interval={0}
+            />
+            <YAxis fontSize={12} />
+            <Tooltip content={<CustomTooltip />} />
+            <Bar 
+              dataKey="conversations" 
+              cursor="pointer"
+              onClick={isDrilldown ? undefined : handleBarClick}
+            >
+              {(isDrilldown ? drilldownData : chartData).map((entry, index) => (
+                <Cell 
+                  key={`cell-${index}`} 
+                  fill={entry.isOthers ? "#f59e0b" : "#3b82f6"}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Stats */}
+      <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-gray-50 rounded-lg p-3">
+          <div className="flex items-center space-x-2">
+            <Building2 className="h-4 w-4 text-gray-500" />
+            <span className="text-sm text-gray-600">
+              {isDrilldown ? "Items Shown" : "Branches Shown"}
+            </span>
+          </div>
+          <p className="text-lg font-semibold text-gray-900">
+            {isDrilldown ? drilldownData.length : chartData.length}
+          </p>
+        </div>
+
+        <div className="bg-gray-50 rounded-lg p-3">
+          <div className="flex items-center space-x-2">
+            <BarChart3 className="h-4 w-4 text-gray-500" />
+            <span className="text-sm text-gray-600">Total Conversations</span>
+          </div>
+          <p className="text-lg font-semibold text-gray-900">
+            {(isDrilldown ? drilldownData : chartData)
+              .reduce((sum, item) => sum + item.conversations, 0)
+              .toLocaleString()}
+          </p>
+        </div>
+
+        <div className="bg-gray-50 rounded-lg p-3">
+          <div className="flex items-center space-x-2">
+            <Calendar className="h-4 w-4 text-gray-500" />
+            <span className="text-sm text-gray-600">Period</span>
+          </div>
+          <p className="text-lg font-semibold text-gray-900">
+            {isDrilldown && drilldownTitle.includes("Monthly") 
+              ? "Last 12 Months" 
+              : selectedMonth ? new Date(selectedMonth + '-01').toLocaleDateString('en-US', { 
+                  year: 'numeric', 
+                  month: 'long' 
+                }) : "—"}
+          </p>
+        </div>
+      </div>
+
+      {!isDrilldown && (
+        <div className="mt-4 text-xs text-gray-500">
+          💡 Click on any bar to see detailed breakdown. "Others" shows remaining branches.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -292,34 +292,74 @@ export function InteractiveBranchChart() {
       </div>
 
       {/* Chart */}
-      <div className="h-96">
+      <div className="h-96 bg-gradient-to-b from-gray-50/30 to-white/30 rounded-xl p-4 border border-gray-100/50">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={isDrilldown ? drilldownData : chartData}
-            margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
+            margin={{ top: 20, right: 30, left: 20, bottom: 70 }}
           >
-            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <defs>
+              <linearGradient id="primaryGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.9} />
+                <stop offset="100%" stopColor="#1d4ed8" stopOpacity={0.8} />
+              </linearGradient>
+              <linearGradient id="othersGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#f59e0b" stopOpacity={0.9} />
+                <stop offset="100%" stopColor="#d97706" stopOpacity={0.8} />
+              </linearGradient>
+              <linearGradient id="drilldownGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#10b981" stopOpacity={0.9} />
+                <stop offset="100%" stopColor="#059669" stopOpacity={0.8} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid
+              strokeDasharray="2 4"
+              stroke="#e5e7eb"
+              strokeOpacity={0.5}
+              vertical={false}
+            />
             <XAxis
               dataKey="name"
               angle={-45}
               textAnchor="end"
               height={80}
-              fontSize={12}
+              fontSize={11}
+              fontWeight={500}
               interval={0}
+              tick={{ fill: '#6b7280' }}
+              axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+              tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
             />
-            <YAxis fontSize={12} />
-            <Tooltip content={<CustomTooltip />} />
+            <YAxis
+              fontSize={11}
+              fontWeight={500}
+              tick={{ fill: '#6b7280' }}
+              axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+              tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+              tickFormatter={(value) => value.toLocaleString()}
+            />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(59, 130, 246, 0.05)' }} />
             <Bar
               dataKey="conversations"
               cursor="pointer"
               onClick={isDrilldown ? undefined : handleBarClick}
+              radius={[4, 4, 0, 0]}
             >
-              {(isDrilldown ? drilldownData : chartData).map((entry, index) => (
-                <Cell
-                  key={`cell-${index}`}
-                  fill={entry.isOthers ? "#f59e0b" : "#3b82f6"}
-                />
-              ))}
+              {(isDrilldown ? drilldownData : chartData).map((entry, index) => {
+                let fillColor = "url(#primaryGradient)";
+                if (isDrilldown) {
+                  fillColor = "url(#drilldownGradient)";
+                } else if (entry.isOthers) {
+                  fillColor = "url(#othersGradient)";
+                }
+
+                return (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={fillColor}
+                  />
+                );
+              })}
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -215,10 +215,20 @@ export function InteractiveBranchChart() {
 
   if (loading) {
     return (
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="flex items-center justify-center py-8">
-          <RefreshCw className="h-5 w-5 animate-spin text-blue-600 mr-2" />
-          <span className="text-gray-600">Loading branch analytics...</span>
+      <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
+        <div className="flex flex-col items-center justify-center py-12">
+          <div className="relative">
+            <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-indigo-600 rounded-xl flex items-center justify-center mb-4">
+              <RefreshCw className="h-6 w-6 animate-spin text-white" />
+            </div>
+            <div className="absolute -inset-1 bg-gradient-to-r from-blue-500/20 to-indigo-600/20 rounded-xl blur animate-pulse"></div>
+          </div>
+          <span className="text-gray-600 font-medium">Loading branch analytics...</span>
+          <div className="mt-3 flex space-x-1">
+            <div className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"></div>
+            <div className="w-2 h-2 bg-indigo-500 rounded-full animate-bounce" style={{animationDelay: '0.1s'}}></div>
+            <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce" style={{animationDelay: '0.2s'}}></div>
+          </div>
         </div>
       </div>
     );
@@ -226,14 +236,22 @@ export function InteractiveBranchChart() {
 
   if (error) {
     return (
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <p className="text-red-600">Error: {error}</p>
+      <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
+        <div className="bg-gradient-to-br from-red-50 to-red-100/50 border border-red-200/50 rounded-xl p-6">
+          <div className="flex items-center space-x-3 mb-3">
+            <div className="p-2 bg-red-500 rounded-lg">
+              <BarChart3 className="h-5 w-5 text-white" />
+            </div>
+            <div>
+              <h4 className="font-semibold text-red-800">Failed to load analytics</h4>
+              <p className="text-red-600 text-sm">{error}</p>
+            </div>
+          </div>
           <button
             onClick={fetchData}
-            className="mt-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+            className="mt-2 px-4 py-2 bg-gradient-to-r from-red-500 to-red-600 text-white rounded-lg hover:from-red-600 hover:to-red-700 transition-all duration-200 font-medium shadow-md"
           >
-            Retry
+            Try Again
           </button>
         </div>
       </div>

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -172,16 +172,27 @@ export function InteractiveBranchChart() {
     }
   };
 
-  // Custom tooltip
+  // Custom tooltip with enhanced design
   const CustomTooltip = ({ active, payload, label }: any) => {
     if (active && payload && payload.length) {
+      const value = payload[0].value;
+      const isOthers = payload[0].payload?.isOthers;
+
       return (
-        <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3">
-          <p className="font-medium text-gray-900">{`${label}`}</p>
-          <p className="text-blue-600">
-            {`Conversations: ${payload[0].value.toLocaleString()}`}
-          </p>
-          <p className="text-xs text-gray-500 mt-1">Click to drill down</p>
+        <div className="bg-white/95 backdrop-blur-sm border border-gray-200/50 rounded-xl shadow-xl p-4 min-w-[200px]">
+          <div className="flex items-center space-x-2 mb-2">
+            <div className={`w-3 h-3 rounded-full ${isOthers ? 'bg-gradient-to-r from-amber-400 to-orange-500' : 'bg-gradient-to-r from-blue-500 to-indigo-600'}`} />
+            <p className="font-semibold text-gray-900 text-sm">{label}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-lg font-bold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+              {value.toLocaleString()} conversations
+            </p>
+            <p className="text-xs text-gray-500 flex items-center space-x-1">
+              <span>🔍</span>
+              <span>Click to explore details</span>
+            </p>
+          </div>
         </div>
       );
     }
@@ -252,8 +263,8 @@ export function InteractiveBranchChart() {
               {isDrilldown ? drilldownTitle : "Conversations by Branch"}
             </h3>
             <p className="text-gray-600">
-              {isDrilldown 
-                ? "Detailed breakdown view" 
+              {isDrilldown
+                ? "Detailed breakdown view"
                 : "Interactive chart showing top 20 branches + others"}
             </p>
           </div>
@@ -269,9 +280,9 @@ export function InteractiveBranchChart() {
             >
               {availableMonths.map(month => (
                 <option key={month} value={month}>
-                  {new Date(month + '-01').toLocaleDateString('en-US', { 
-                    year: 'numeric', 
-                    month: 'long' 
+                  {new Date(month + '-01').toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long'
                   })}
                 </option>
               ))}
@@ -288,8 +299,8 @@ export function InteractiveBranchChart() {
             margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
           >
             <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-            <XAxis 
-              dataKey="name" 
+            <XAxis
+              dataKey="name"
               angle={-45}
               textAnchor="end"
               height={80}
@@ -298,14 +309,14 @@ export function InteractiveBranchChart() {
             />
             <YAxis fontSize={12} />
             <Tooltip content={<CustomTooltip />} />
-            <Bar 
-              dataKey="conversations" 
+            <Bar
+              dataKey="conversations"
               cursor="pointer"
               onClick={isDrilldown ? undefined : handleBarClick}
             >
               {(isDrilldown ? drilldownData : chartData).map((entry, index) => (
-                <Cell 
-                  key={`cell-${index}`} 
+                <Cell
+                  key={`cell-${index}`}
                   fill={entry.isOthers ? "#f59e0b" : "#3b82f6"}
                 />
               ))}
@@ -346,11 +357,11 @@ export function InteractiveBranchChart() {
             <span className="text-sm text-gray-600">Period</span>
           </div>
           <p className="text-lg font-semibold text-gray-900">
-            {isDrilldown && drilldownTitle.includes("Monthly") 
-              ? "Last 12 Months" 
-              : selectedMonth ? new Date(selectedMonth + '-01').toLocaleDateString('en-US', { 
-                  year: 'numeric', 
-                  month: 'long' 
+            {isDrilldown && drilldownTitle.includes("Monthly")
+              ? "Last 12 Months"
+              : selectedMonth ? new Date(selectedMonth + '-01').toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long'
                 }) : "—"}
           </p>
         </div>

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -243,26 +243,26 @@ export function InteractiveBranchChart() {
   const availableMonths = getAvailableMonths();
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
+    <div className="bg-gradient-to-br from-white to-gray-50/50 rounded-2xl shadow-lg border border-gray-100/50 p-8">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center space-x-3">
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center space-x-4">
           {isDrilldown && (
             <button
               onClick={() => setIsDrilldown(false)}
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              className="p-3 hover:bg-gradient-to-r hover:from-gray-100 hover:to-gray-50 rounded-xl transition-all duration-200 group"
             >
-              <ChevronLeft className="h-5 w-5 text-gray-600" />
+              <ChevronLeft className="h-5 w-5 text-gray-600 group-hover:text-gray-800 transition-colors" />
             </button>
           )}
-          <div className="p-2 bg-blue-100 rounded-lg">
-            <BarChart3 className="h-6 w-6 text-blue-600" />
+          <div className="p-3 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-xl shadow-md">
+            <BarChart3 className="h-7 w-7 text-white" />
           </div>
           <div>
-            <h3 className="text-lg font-semibold text-gray-900">
+            <h3 className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
               {isDrilldown ? drilldownTitle : "Conversations by Branch"}
             </h3>
-            <p className="text-gray-600">
+            <p className="text-gray-600 text-sm mt-1">
               {isDrilldown
                 ? "Detailed breakdown view"
                 : "Interactive chart showing top 20 branches + others"}
@@ -271,12 +271,12 @@ export function InteractiveBranchChart() {
         </div>
 
         {!isDrilldown && (
-          <div className="flex items-center space-x-2">
-            <Calendar className="h-4 w-4 text-gray-500" />
+          <div className="flex items-center space-x-3 bg-white/70 backdrop-blur-sm rounded-xl px-4 py-2 border border-gray-200/50">
+            <Calendar className="h-4 w-4 text-indigo-500" />
             <select
               value={selectedMonth}
               onChange={(e) => setSelectedMonth(e.target.value)}
-              className="border border-gray-200 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="bg-transparent border-none outline-none text-sm font-medium text-gray-700 cursor-pointer"
             >
               {availableMonths.map(month => (
                 <option key={month} value={month}>

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -420,8 +420,12 @@ export function InteractiveBranchChart() {
       </div>
 
       {!isDrilldown && (
-        <div className="mt-4 text-xs text-gray-500">
-          💡 Click on any bar to see detailed breakdown. "Others" shows remaining branches.
+        <div className="mt-6 bg-gradient-to-r from-blue-50/50 to-indigo-50/50 rounded-xl p-4 border border-blue-100/30">
+          <div className="flex items-center space-x-2 text-sm text-blue-700">
+            <span className="text-lg">💡</span>
+            <span className="font-medium">Pro tip:</span>
+            <span>Click on any bar to see detailed breakdown. "Others" shows remaining branches.</span>
+          </div>
         </div>
       )}
     </div>

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -54,7 +54,9 @@ export function InteractiveBranchChart() {
 
   // Get available months from data
   const getAvailableMonths = () => {
-    const months = [...new Set(rawData.map(item => item.month))].sort().reverse();
+    const months = [...new Set(rawData.map((item) => item.month))]
+      .sort()
+      .reverse();
     return months;
   };
 
@@ -63,7 +65,9 @@ export function InteractiveBranchChart() {
       setLoading(true);
       setError(null);
 
-      const response = await authFetch("/api/analytics/conversations/branch-monthly");
+      const response = await authFetch(
+        "/api/analytics/conversations/branch-monthly",
+      );
       if (!response.ok) {
         throw new Error("Failed to fetch branch monthly data");
       }
@@ -72,7 +76,9 @@ export function InteractiveBranchChart() {
       setRawData(data);
 
       // Set default month to the latest available
-      const availableMonths = [...new Set(data.map(item => item.month))].sort().reverse();
+      const availableMonths = [...new Set(data.map((item) => item.month))]
+        .sort()
+        .reverse();
       if (availableMonths.length > 0 && !selectedMonth) {
         setSelectedMonth(availableMonths[0]);
       }
@@ -89,26 +95,31 @@ export function InteractiveBranchChart() {
     if (!selectedMonth || rawData.length === 0) return;
 
     // Filter data for selected month
-    const monthData = rawData.filter(item => item.month === selectedMonth);
+    const monthData = rawData.filter((item) => item.month === selectedMonth);
 
     // Group by branch and sum conversations
-    const branchTotals = monthData.reduce((acc, item) => {
-      const key = item.branch_name;
-      if (!acc[key]) {
-        acc[key] = {
-          name: item.branch_name,
-          conversations: 0,
-          branch_id: item.branch_id,
-          details: []
-        };
-      }
-      acc[key].conversations += item.count;
-      acc[key].details.push(item);
-      return acc;
-    }, {} as Record<string, ChartData>);
+    const branchTotals = monthData.reduce(
+      (acc, item) => {
+        const key = item.branch_name;
+        if (!acc[key]) {
+          acc[key] = {
+            name: item.branch_name,
+            conversations: 0,
+            branch_id: item.branch_id,
+            details: [],
+          };
+        }
+        acc[key].conversations += item.count;
+        acc[key].details.push(item);
+        return acc;
+      },
+      {} as Record<string, ChartData>,
+    );
 
     // Sort by conversations count
-    const sortedBranches = Object.values(branchTotals).sort((a, b) => b.conversations - a.conversations);
+    const sortedBranches = Object.values(branchTotals).sort(
+      (a, b) => b.conversations - a.conversations,
+    );
 
     // Take top 20 and group others
     const top20 = sortedBranches.slice(0, 20);
@@ -118,12 +129,15 @@ export function InteractiveBranchChart() {
 
     // Add "Others" group if there are more than 20 branches
     if (others.length > 0) {
-      const othersTotal = others.reduce((sum, branch) => sum + branch.conversations, 0);
+      const othersTotal = others.reduce(
+        (sum, branch) => sum + branch.conversations,
+        0,
+      );
       chartData.push({
         name: "Others",
         conversations: othersTotal,
         isOthers: true,
-        details: others.flatMap(branch => branch.details || [])
+        details: others.flatMap((branch) => branch.details || []),
       });
     }
 
@@ -135,21 +149,23 @@ export function InteractiveBranchChart() {
     if (data.isOthers) {
       // Show breakdown of "Others" branches
       const othersBreakdown = rawData
-        .filter(item => item.month === selectedMonth)
+        .filter((item) => item.month === selectedMonth)
         .reduce((acc, item) => {
-          const existing = acc.find(x => x.name === item.branch_name);
+          const existing = acc.find((x) => x.name === item.branch_name);
           if (existing) {
             existing.conversations += item.count;
           } else {
             acc.push({
               name: item.branch_name,
               conversations: item.count,
-              month: item.month
+              month: item.month,
             });
           }
           return acc;
         }, [] as DrilldownData[])
-        .filter(item => !chartData.slice(0, 20).find(c => c.name === item.name))
+        .filter(
+          (item) => !chartData.slice(0, 20).find((c) => c.name === item.name),
+        )
         .sort((a, b) => b.conversations - a.conversations);
 
       setDrilldownData(othersBreakdown);
@@ -158,11 +174,11 @@ export function InteractiveBranchChart() {
     } else {
       // Show monthly breakdown for specific branch
       const branchMonthly = rawData
-        .filter(item => item.branch_name === data.name)
-        .map(item => ({
+        .filter((item) => item.branch_name === data.name)
+        .map((item) => ({
           name: item.month,
           conversations: item.count,
-          month: item.month
+          month: item.month,
         }))
         .sort((a, b) => b.month.localeCompare(a.month));
 
@@ -181,7 +197,9 @@ export function InteractiveBranchChart() {
       return (
         <div className="bg-white/95 backdrop-blur-sm border border-gray-200/50 rounded-xl shadow-xl p-4 min-w-[200px]">
           <div className="flex items-center space-x-2 mb-2">
-            <div className={`w-3 h-3 rounded-full ${isOthers ? 'bg-gradient-to-r from-amber-400 to-orange-500' : 'bg-gradient-to-r from-blue-500 to-indigo-600'}`} />
+            <div
+              className={`w-3 h-3 rounded-full ${isOthers ? "bg-gradient-to-r from-amber-400 to-orange-500" : "bg-gradient-to-r from-blue-500 to-indigo-600"}`}
+            />
             <p className="font-semibold text-gray-900 text-sm">{label}</p>
           </div>
           <div className="space-y-1">
@@ -223,11 +241,19 @@ export function InteractiveBranchChart() {
             </div>
             <div className="absolute -inset-1 bg-gradient-to-r from-blue-500/20 to-indigo-600/20 rounded-xl blur animate-pulse"></div>
           </div>
-          <span className="text-gray-600 font-medium">Loading branch analytics...</span>
+          <span className="text-gray-600 font-medium">
+            Loading branch analytics...
+          </span>
           <div className="mt-3 flex space-x-1">
             <div className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"></div>
-            <div className="w-2 h-2 bg-indigo-500 rounded-full animate-bounce" style={{animationDelay: '0.1s'}}></div>
-            <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce" style={{animationDelay: '0.2s'}}></div>
+            <div
+              className="w-2 h-2 bg-indigo-500 rounded-full animate-bounce"
+              style={{ animationDelay: "0.1s" }}
+            ></div>
+            <div
+              className="w-2 h-2 bg-purple-500 rounded-full animate-bounce"
+              style={{ animationDelay: "0.2s" }}
+            ></div>
           </div>
         </div>
       </div>
@@ -243,7 +269,9 @@ export function InteractiveBranchChart() {
               <BarChart3 className="h-5 w-5 text-white" />
             </div>
             <div>
-              <h4 className="font-semibold text-red-800">Failed to load analytics</h4>
+              <h4 className="font-semibold text-red-800">
+                Failed to load analytics
+              </h4>
               <p className="text-red-600 text-sm">{error}</p>
             </div>
           </div>
@@ -296,11 +324,11 @@ export function InteractiveBranchChart() {
               onChange={(e) => setSelectedMonth(e.target.value)}
               className="bg-transparent border-none outline-none text-sm font-medium text-gray-700 cursor-pointer"
             >
-              {availableMonths.map(month => (
+              {availableMonths.map((month) => (
                 <option key={month} value={month}>
-                  {new Date(month + '-01').toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long'
+                  {new Date(month + "-01").toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
                   })}
                 </option>
               ))}
@@ -325,7 +353,13 @@ export function InteractiveBranchChart() {
                 <stop offset="0%" stopColor="#f59e0b" stopOpacity={0.9} />
                 <stop offset="100%" stopColor="#d97706" stopOpacity={0.8} />
               </linearGradient>
-              <linearGradient id="drilldownGradient" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient
+                id="drilldownGradient"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
                 <stop offset="0%" stopColor="#10b981" stopOpacity={0.9} />
                 <stop offset="100%" stopColor="#059669" stopOpacity={0.8} />
               </linearGradient>
@@ -344,19 +378,22 @@ export function InteractiveBranchChart() {
               fontSize={11}
               fontWeight={500}
               interval={0}
-              tick={{ fill: '#6b7280' }}
-              axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-              tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+              tick={{ fill: "#6b7280" }}
+              axisLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
+              tickLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
             />
             <YAxis
               fontSize={11}
               fontWeight={500}
-              tick={{ fill: '#6b7280' }}
-              axisLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
-              tickLine={{ stroke: '#d1d5db', strokeWidth: 1 }}
+              tick={{ fill: "#6b7280" }}
+              axisLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
+              tickLine={{ stroke: "#d1d5db", strokeWidth: 1 }}
               tickFormatter={(value) => value.toLocaleString()}
             />
-            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(59, 130, 246, 0.05)' }} />
+            <Tooltip
+              content={<CustomTooltip />}
+              cursor={{ fill: "rgba(59, 130, 246, 0.05)" }}
+            />
             <Bar
               dataKey="conversations"
               cursor="pointer"
@@ -371,12 +408,7 @@ export function InteractiveBranchChart() {
                   fillColor = "url(#othersGradient)";
                 }
 
-                return (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={fillColor}
-                  />
-                );
+                return <Cell key={`cell-${index}`} fill={fillColor} />;
               })}
             </Bar>
           </BarChart>
@@ -407,7 +439,9 @@ export function InteractiveBranchChart() {
               <div className="p-2 bg-gradient-to-br from-emerald-500 to-green-600 rounded-lg">
                 <BarChart3 className="h-4 w-4 text-white" />
               </div>
-              <span className="text-sm font-medium text-emerald-700">Total Conversations</span>
+              <span className="text-sm font-medium text-emerald-700">
+                Total Conversations
+              </span>
             </div>
           </div>
           <p className="text-2xl font-bold text-emerald-900">
@@ -423,16 +457,20 @@ export function InteractiveBranchChart() {
               <div className="p-2 bg-gradient-to-br from-purple-500 to-violet-600 rounded-lg">
                 <Calendar className="h-4 w-4 text-white" />
               </div>
-              <span className="text-sm font-medium text-purple-700">Period</span>
+              <span className="text-sm font-medium text-purple-700">
+                Period
+              </span>
             </div>
           </div>
           <p className="text-2xl font-bold text-purple-900">
             {isDrilldown && drilldownTitle.includes("Monthly")
               ? "Last 12M"
-              : selectedMonth ? new Date(selectedMonth + '-01').toLocaleDateString('en-US', {
-                  month: 'short',
-                  year: 'numeric'
-                }) : "—"}
+              : selectedMonth
+                ? new Date(selectedMonth + "-01").toLocaleDateString("en-US", {
+                    month: "short",
+                    year: "numeric",
+                  })
+                : "—"}
           </p>
         </div>
       </div>
@@ -442,7 +480,10 @@ export function InteractiveBranchChart() {
           <div className="flex items-center space-x-2 text-sm text-blue-700">
             <span className="text-lg">💡</span>
             <span className="font-medium">Pro tip:</span>
-            <span>Click on any bar to see detailed breakdown. "Others" shows remaining branches.</span>
+            <span>
+              Click on any bar to see detailed breakdown. "Others" shows
+              remaining branches.
+            </span>
           </div>
         </div>
       )}

--- a/client/components/InteractiveBranchChart.tsx
+++ b/client/components/InteractiveBranchChart.tsx
@@ -366,42 +366,54 @@ export function InteractiveBranchChart() {
       </div>
 
       {/* Stats */}
-      <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-gray-50 rounded-lg p-3">
-          <div className="flex items-center space-x-2">
-            <Building2 className="h-4 w-4 text-gray-500" />
-            <span className="text-sm text-gray-600">
-              {isDrilldown ? "Items Shown" : "Branches Shown"}
-            </span>
+      <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-gradient-to-br from-blue-50 to-indigo-50/50 rounded-xl p-4 border border-blue-100/50">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center space-x-2">
+              <div className="p-2 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg">
+                <Building2 className="h-4 w-4 text-white" />
+              </div>
+              <span className="text-sm font-medium text-blue-700">
+                {isDrilldown ? "Items Shown" : "Branches Shown"}
+              </span>
+            </div>
           </div>
-          <p className="text-lg font-semibold text-gray-900">
+          <p className="text-2xl font-bold text-blue-900">
             {isDrilldown ? drilldownData.length : chartData.length}
           </p>
         </div>
 
-        <div className="bg-gray-50 rounded-lg p-3">
-          <div className="flex items-center space-x-2">
-            <BarChart3 className="h-4 w-4 text-gray-500" />
-            <span className="text-sm text-gray-600">Total Conversations</span>
+        <div className="bg-gradient-to-br from-emerald-50 to-green-50/50 rounded-xl p-4 border border-emerald-100/50">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center space-x-2">
+              <div className="p-2 bg-gradient-to-br from-emerald-500 to-green-600 rounded-lg">
+                <BarChart3 className="h-4 w-4 text-white" />
+              </div>
+              <span className="text-sm font-medium text-emerald-700">Total Conversations</span>
+            </div>
           </div>
-          <p className="text-lg font-semibold text-gray-900">
+          <p className="text-2xl font-bold text-emerald-900">
             {(isDrilldown ? drilldownData : chartData)
               .reduce((sum, item) => sum + item.conversations, 0)
               .toLocaleString()}
           </p>
         </div>
 
-        <div className="bg-gray-50 rounded-lg p-3">
-          <div className="flex items-center space-x-2">
-            <Calendar className="h-4 w-4 text-gray-500" />
-            <span className="text-sm text-gray-600">Period</span>
+        <div className="bg-gradient-to-br from-purple-50 to-violet-50/50 rounded-xl p-4 border border-purple-100/50">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center space-x-2">
+              <div className="p-2 bg-gradient-to-br from-purple-500 to-violet-600 rounded-lg">
+                <Calendar className="h-4 w-4 text-white" />
+              </div>
+              <span className="text-sm font-medium text-purple-700">Period</span>
+            </div>
           </div>
-          <p className="text-lg font-semibold text-gray-900">
+          <p className="text-2xl font-bold text-purple-900">
             {isDrilldown && drilldownTitle.includes("Monthly")
-              ? "Last 12 Months"
+              ? "Last 12M"
               : selectedMonth ? new Date(selectedMonth + '-01').toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long'
+                  month: 'short',
+                  year: 'numeric'
                 }) : "—"}
           </p>
         </div>

--- a/client/pages/Complaints.tsx
+++ b/client/pages/Complaints.tsx
@@ -676,53 +676,7 @@ export function Complaints() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
-
-      {/* Internal Navigation Tabs */}
-      <div className="bg-white border-b border-gray-200 shadow-sm">
-        <div className="flex items-center justify-start py-4 px-4">
-          <div className="flex items-center space-x-3">
-            <button
-              onClick={() => navigate("/")}
-              className="flex flex-col items-center px-6 py-4 rounded-lg text-gray-600 hover:text-gray-800 hover:bg-gray-50 transition-all duration-200 min-w-[90px]"
-            >
-              <Grid3X3 className="w-6 h-6 mb-2" />
-              <span className="text-sm font-medium">Home</span>
-            </button>
-
-            <button
-              onClick={() => {
-                setActiveTab("analytics");
-                navigate("/complaints?tab=analytics", { replace: true });
-              }}
-              className={cn(
-                "flex flex-col items-center px-6 py-4 rounded-lg transition-all duration-200 min-w-[90px]",
-                activeTab === "analytics"
-                  ? "text-primary bg-primary/5 border-2 border-primary/20 shadow-sm"
-                  : "text-gray-600 hover:text-gray-800 hover:bg-gray-50",
-              )}
-            >
-              <BarChart3 className="w-6 h-6 mb-2" />
-              <span className="text-sm font-medium">Analytics</span>
-            </button>
-
-            <button
-              onClick={() => {
-                setActiveTab("complaints");
-                navigate("/complaints", { replace: true });
-              }}
-              className={cn(
-                "flex flex-col items-center px-6 py-4 rounded-lg transition-all duration-200 min-w-[90px]",
-                activeTab === "complaints"
-                  ? "text-primary bg-primary/5 border-2 border-primary/20 shadow-sm"
-                  : "text-gray-600 hover:text-gray-800 hover:bg-gray-50",
-              )}
-            >
-              <Mail className="w-6 h-6 mb-2" />
-              <span className="text-sm font-medium">Complaints</span>
-            </button>
-          </div>
-        </div>
-      </div>
+      <AdminNavigation />
 
       <div className="px-6 py-6">
         {/* Complaints Tab Content */}

--- a/client/pages/Complaints.tsx
+++ b/client/pages/Complaints.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { Header } from "../components/Header";
+import { AdminNavigation } from "../components/AdminNavigation";
 import { useNavigate } from "react-router-dom";
 import {
   Mail,

--- a/server/index.ts
+++ b/server/index.ts
@@ -51,6 +51,7 @@ import {
   getDailyConversationsLastMonth,
   getUniqueCnicsByMonth,
 } from "./routes/conversation-analytics";
+import { getVoiceStreamsAnalytics } from "./routes/voice-streams-analytics";
 import {
   getUsers,
   createUser,

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,6 +46,7 @@ import { getRecordingsAnalytics } from "./routes/analytics-db";
 import {
   getConversationAnalytics,
   getConversationsByBranch,
+  getConversationsByBranchPerMonth,
   getConversationsByCity,
   getDailyConversationsLastMonth,
   getUniqueCnicsByMonth,

--- a/server/index.ts
+++ b/server/index.ts
@@ -205,6 +205,12 @@ export function createServer() {
     addBranchFilter(),
     getUniqueCnicsByMonth,
   );
+  app.get(
+    "/api/analytics/voice-streams",
+    authenticate,
+    addBranchFilter(),
+    getVoiceStreamsAnalytics,
+  );
 
   // User Management routes
   app.post("/api/auth/login", loginUser);

--- a/server/index.ts
+++ b/server/index.ts
@@ -180,6 +180,12 @@ export function createServer() {
     getConversationsByBranch,
   );
   app.get(
+    "/api/analytics/conversations/branch-monthly",
+    authenticate,
+    addBranchFilter(),
+    getConversationsByBranchPerMonth,
+  );
+  app.get(
     "/api/analytics/conversations/city",
     authenticate,
     addBranchFilter(),

--- a/server/routes/conversation-analytics.ts
+++ b/server/routes/conversation-analytics.ts
@@ -204,6 +204,12 @@ export const getUniqueCnicsByMonth: RequestHandler = async (req, res) => {
 // Get complete conversation analytics
 export const getConversationAnalytics: RequestHandler = async (req, res) => {
   try {
+    // Get branch filter from middleware
+    const branchFilter = (req as any).branchFilter;
+    const branchFilterCondition = branchFilter
+      ? `AND ldbu.branch_id = '${branchFilter.value}'`
+      : '';
+
     // 1. Number of conversations according to branch
     const branchQuery = `
       SELECT
@@ -214,7 +220,7 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
       LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
       LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
       LEFT JOIN branches b ON b.id = ldbu.branch_id
-      WHERE ldbu.branch_id IS NOT NULL
+      WHERE ldbu.branch_id IS NOT NULL ${branchFilterCondition}
       GROUP BY ldbu.branch_id
       ORDER BY count DESC
     `;
@@ -229,7 +235,7 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
       LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
       LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
       LEFT JOIN branches b ON b.id = ldbu.branch_id
-      WHERE b.branch_city IS NOT NULL
+      WHERE b.branch_city IS NOT NULL ${branchFilterCondition}
       GROUP BY b.branch_city
       ORDER BY conversion_count DESC
     `;
@@ -241,7 +247,11 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
         COUNT(CASE WHEN r.end_time IS NOT NULL AND r.file_name IS NOT NULL THEN 1 END) AS conversion_count,
         COUNT(r.id) AS total_conversations
       FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
       WHERE r.start_time >= DATE_SUB(CURDATE(), INTERVAL 1 MONTH)
+        ${branchFilterCondition}
       GROUP BY DATE(r.start_time)
       ORDER BY date
     `;
@@ -251,10 +261,14 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
       SELECT
         COUNT(DISTINCT REPLACE(r.cnic, '-', '')) AS unique_cnic_count
       FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
       WHERE YEAR(r.start_time) = YEAR(CURDATE())
         AND MONTH(r.start_time) = MONTH(CURDATE())
         AND r.cnic IS NOT NULL
         AND r.cnic != ''
+        ${branchFilterCondition}
     `;
 
     // Total statistics
@@ -269,6 +283,7 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
       LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
       LEFT JOIN branches b ON b.id = ldbu.branch_id
       WHERE r.start_time >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
+        ${branchFilterCondition}
     `;
 
     // Conversion analytics queries
@@ -279,7 +294,11 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
         AVG(CASE WHEN r.end_time IS NOT NULL THEN TIMESTAMPDIFF(SECOND, r.start_time, r.end_time) ELSE r.duration_seconds END) as avgConversationDuration,
         COUNT(CASE WHEN r.end_time IS NOT NULL AND r.file_name IS NOT NULL AND TIMESTAMPDIFF(SECOND, r.start_time, r.end_time) >= 120 THEN 1 END) as successfulOutcomes
       FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
       WHERE r.start_time >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)
+        ${branchFilterCondition}
     `;
 
     const conversionsByBranchQuery = `
@@ -293,6 +312,7 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
       LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
       LEFT JOIN branches b ON b.id = ldbu.branch_id
       WHERE r.start_time >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)
+        ${branchFilterCondition}
       GROUP BY b.branch_address
       HAVING COUNT(r.id) > 0
       ORDER BY conversion_rate DESC

--- a/server/routes/conversation-analytics.ts
+++ b/server/routes/conversation-analytics.ts
@@ -91,6 +91,12 @@ export const getConversationsByBranch: RequestHandler = async (req, res) => {
 // Get conversations per branch per month for interactive chart
 export const getConversationsByBranchPerMonth: RequestHandler = async (req, res) => {
   try {
+    // Get branch filter from middleware
+    const branchFilter = (req as any).branchFilter;
+    const branchFilterCondition = branchFilter
+      ? `AND ldbu.branch_id = '${branchFilter.value}'`
+      : '';
+
     const query = `
       SELECT
         ldbu.branch_id,
@@ -104,6 +110,7 @@ export const getConversationsByBranchPerMonth: RequestHandler = async (req, res)
       LEFT JOIN branches b ON b.id = ldbu.branch_id
       WHERE ldbu.branch_id IS NOT NULL
         AND r.start_time >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
+        ${branchFilterCondition}
       GROUP BY ldbu.branch_id, b.branch_address, b.branch_city, DATE_FORMAT(r.start_time, '%Y-%m')
       ORDER BY month DESC, count DESC
     `;

--- a/server/routes/conversation-analytics.ts
+++ b/server/routes/conversation-analytics.ts
@@ -59,7 +59,7 @@ export const getConversationsByBranch: RequestHandler = async (req, res) => {
     const branchFilter = (req as any).branchFilter;
     const branchFilterCondition = branchFilter
       ? `AND ldbu.branch_id = '${branchFilter.value}'`
-      : '';
+      : "";
 
     const query = `
       SELECT
@@ -89,13 +89,16 @@ export const getConversationsByBranch: RequestHandler = async (req, res) => {
 };
 
 // Get conversations per branch per month for interactive chart
-export const getConversationsByBranchPerMonth: RequestHandler = async (req, res) => {
+export const getConversationsByBranchPerMonth: RequestHandler = async (
+  req,
+  res,
+) => {
   try {
     // Get branch filter from middleware
     const branchFilter = (req as any).branchFilter;
     const branchFilterCondition = branchFilter
       ? `AND ldbu.branch_id = '${branchFilter.value}'`
-      : '';
+      : "";
 
     const query = `
       SELECT
@@ -126,7 +129,9 @@ export const getConversationsByBranchPerMonth: RequestHandler = async (req, res)
     res.json(result);
   } catch (error) {
     console.error("Error fetching conversations by branch per month:", error);
-    res.status(500).json({ error: "Failed to fetch conversations by branch per month" });
+    res
+      .status(500)
+      .json({ error: "Failed to fetch conversations by branch per month" });
   }
 };
 
@@ -137,7 +142,7 @@ export const getConversationsByCity: RequestHandler = async (req, res) => {
     const branchFilter = (req as any).branchFilter;
     const branchFilterCondition = branchFilter
       ? `AND ldbu.branch_id = '${branchFilter.value}'`
-      : '';
+      : "";
 
     const query = `
       SELECT
@@ -176,7 +181,7 @@ export const getDailyConversationsLastMonth: RequestHandler = async (
     const branchFilter = (req as any).branchFilter;
     const branchFilterCondition = branchFilter
       ? `AND ldbu.branch_id = '${branchFilter.value}'`
-      : '';
+      : "";
 
     const query = `
       SELECT
@@ -211,7 +216,7 @@ export const getUniqueCnicsByMonth: RequestHandler = async (req, res) => {
     const branchFilter = (req as any).branchFilter;
     const branchFilterCondition = branchFilter
       ? `AND ldbu.branch_id = '${branchFilter.value}'`
-      : '';
+      : "";
 
     const query = `
       SELECT
@@ -247,7 +252,7 @@ export const getConversationAnalytics: RequestHandler = async (req, res) => {
     const branchFilter = (req as any).branchFilter;
     const branchFilterCondition = branchFilter
       ? `AND ldbu.branch_id = '${branchFilter.value}'`
-      : '';
+      : "";
 
     // 1. Number of conversations according to branch
     const branchQuery = `

--- a/server/routes/conversation-analytics.ts
+++ b/server/routes/conversation-analytics.ts
@@ -55,6 +55,12 @@ export interface ConversationAnalytics {
 // Get conversations analytics by branch
 export const getConversationsByBranch: RequestHandler = async (req, res) => {
   try {
+    // Get branch filter from middleware
+    const branchFilter = (req as any).branchFilter;
+    const branchFilterCondition = branchFilter
+      ? `AND ldbu.branch_id = '${branchFilter.value}'`
+      : '';
+
     const query = `
       SELECT
         ldbu.branch_id,
@@ -64,7 +70,7 @@ export const getConversationsByBranch: RequestHandler = async (req, res) => {
       LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
       LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
       LEFT JOIN branches b ON b.id = ldbu.branch_id
-      WHERE ldbu.branch_id IS NOT NULL
+      WHERE ldbu.branch_id IS NOT NULL ${branchFilterCondition}
       GROUP BY ldbu.branch_id
       ORDER BY count DESC
     `;

--- a/server/routes/heartbeat-db.ts
+++ b/server/routes/heartbeat-db.ts
@@ -91,13 +91,16 @@ export const getHeartbeats: RequestHandler = async (req: any, res) => {
           '0h 0m' AS uptime_duration_24h
         FROM heartbeat
         WHERE mac_address IS NOT NULL
-        ${branchFilter ? '' : ''}
+        ${branchFilter ? "" : ""}
         GROUP BY mac_address, ip_address
         ORDER BY MAX(created_on) DESC
         LIMIT 50
       `;
 
-      heartbeats = await executeQuery<HeartbeatRecord>(fallbackQuery, branchFilter ? [] : []);
+      heartbeats = await executeQuery<HeartbeatRecord>(
+        fallbackQuery,
+        branchFilter ? [] : [],
+      );
     }
 
     const duration = Date.now() - startTime;

--- a/server/routes/heartbeat-db.ts
+++ b/server/routes/heartbeat-db.ts
@@ -29,10 +29,10 @@ export const getHeartbeats: RequestHandler = async (req: any, res) => {
       queryParams.push(branchFilter.value);
     }
 
-    // Query the heartbeat table with device and branch info
+    // Simplified and optimized heartbeat query
     const query = `
       SELECT
-        COALESCE(b.branch_address, h.mac_address) AS branch_name,
+        COALESCE(b.branch_address, CONCAT('Device-', h.mac_address)) AS branch_name,
         COALESCE(b.branch_code, h.ip_address) AS branch_code,
         h.last_seen,
         CASE
@@ -41,31 +41,34 @@ export const getHeartbeats: RequestHandler = async (req: any, res) => {
           ELSE 'offline'
         END AS status,
         CONCAT(
-          FLOOR(IFNULL(u.heartbeat_count, 0) * 30 / 3600), 'h ',
-          FLOOR(MOD(IFNULL(u.heartbeat_count, 0) * 30, 3600) / 60), 'm'
+          FLOOR(IFNULL(h.uptime_count, 0) * 30 / 3600), 'h ',
+          FLOOR(MOD(IFNULL(h.uptime_count, 0) * 30, 3600) / 60), 'm'
         ) AS uptime_duration_24h
       FROM (
         SELECT
-          mac_address,
-          MAX(ip_address) AS ip_address,
-          MAX(created_on) AS last_seen
-        FROM heartbeat
-        WHERE mac_address IS NOT NULL
-        GROUP BY mac_address
+          h1.mac_address,
+          h1.ip_address,
+          h1.created_on AS last_seen,
+          (
+            SELECT COUNT(*)
+            FROM heartbeat h2
+            WHERE h2.mac_address = h1.mac_address
+              AND h2.created_on >= DATE_SUB(NOW(), INTERVAL 1 DAY)
+          ) AS uptime_count
+        FROM heartbeat h1
+        WHERE h1.created_on = (
+          SELECT MAX(h3.created_on)
+          FROM heartbeat h3
+          WHERE h3.mac_address = h1.mac_address
+        )
+        AND h1.mac_address IS NOT NULL
       ) h
-      LEFT JOIN (
-        SELECT
-          mac_address,
-          COUNT(*) AS heartbeat_count
-        FROM heartbeat
-        WHERE created_on >= NOW() - INTERVAL 1 DAY
-        GROUP BY mac_address
-      ) u ON u.mac_address = h.mac_address
       LEFT JOIN devices d ON d.device_mac = h.mac_address
-      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id COLLATE utf8mb4_0900_ai_ci = d.id COLLATE utf8mb4_0900_ai_ci
-      LEFT JOIN branches b ON b.id COLLATE utf8mb4_0900_ai_ci = ldbu.branch_id COLLATE utf8mb4_0900_ai_ci
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
       ${whereClause}
       ORDER BY h.last_seen DESC
+      LIMIT 100
     `;
 
     const heartbeats = await executeQuery<HeartbeatRecord>(query, queryParams);

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -85,7 +85,7 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
     ]);
 
     // Generate last 12 months array to fill missing months with 0
-    const last12Months = [];
+    const last12Months: VoiceStreamMonthlyData[] = [];
     for (let i = 11; i >= 0; i--) {
       const date = new Date();
       date.setMonth(date.getMonth() - i);

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -4,6 +4,7 @@ import { executeQuery } from "../config/database";
 interface VoiceStreamMonthlyData {
   month: string;
   voice_streams: number;
+  formatted_month: string;
 }
 
 interface VoiceStreamStats {

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -7,11 +7,18 @@ interface VoiceStreamMonthlyData {
   formatted_month: string;
 }
 
+interface VoiceStreamDailyData {
+  date: string;
+  voice_streams: number;
+  formatted_date: string;
+}
+
 interface VoiceStreamStats {
   total_streams: number;
   current_month_streams: number;
   previous_month_streams: number;
   monthly_data: VoiceStreamMonthlyData[];
+  daily_current_month: VoiceStreamDailyData[];
 }
 
 // Get voice streams analytics for branch users

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -79,6 +79,22 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       ORDER BY month ASC
     `;
 
+    // Get daily voice streams for current month
+    const dailyCurrentMonthQuery = `
+      SELECT
+        DATE(r.start_time) as date,
+        COUNT(*) as voice_streams
+      FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
+      WHERE YEAR(r.start_time) = YEAR(CURDATE())
+        AND MONTH(r.start_time) = MONTH(CURDATE())
+        ${branchFilterCondition}
+      GROUP BY DATE(r.start_time)
+      ORDER BY date ASC
+    `;
+
     // Execute all queries in parallel
     const [
       totalResult,

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -28,7 +28,7 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
     const branchFilter = (req as any).branchFilter;
     const branchFilterCondition = branchFilter
       ? `AND ldbu.branch_id = '${branchFilter.value}'`
-      : '';
+      : "";
 
     // Get total voice streams count
     const totalQuery = `
@@ -101,13 +101,15 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       currentMonthResult,
       previousMonthResult,
       monthlyResult,
-      dailyCurrentMonthResult
+      dailyCurrentMonthResult,
     ] = await Promise.all([
       executeQuery<{ total_streams: number }>(totalQuery),
       executeQuery<{ current_month_streams: number }>(currentMonthQuery),
       executeQuery<{ previous_month_streams: number }>(previousMonthQuery),
       executeQuery<{ month: string; voice_streams: number }>(monthlyQuery),
-      executeQuery<{ date: string; voice_streams: number }>(dailyCurrentMonthQuery)
+      executeQuery<{ date: string; voice_streams: number }>(
+        dailyCurrentMonthQuery,
+      ),
     ]);
 
     // Generate last 12 months array to fill missing months with 0
@@ -116,16 +118,18 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       const date = new Date();
       date.setMonth(date.getMonth() - i);
       const monthKey = date.toISOString().slice(0, 7); // YYYY-MM format
-      const formattedMonth = date.toLocaleDateString('en-US', {
-        month: 'short',
-        year: 'numeric'
+      const formattedMonth = date.toLocaleDateString("en-US", {
+        month: "short",
+        year: "numeric",
       });
 
-      const existingData = monthlyResult.find(item => item.month === monthKey);
+      const existingData = monthlyResult.find(
+        (item) => item.month === monthKey,
+      );
       last12Months.push({
         month: monthKey,
         voice_streams: existingData ? existingData.voice_streams : 0,
-        formatted_month: formattedMonth
+        formatted_month: formattedMonth,
       });
     }
 
@@ -139,25 +143,28 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
     for (let day = 1; day <= daysInMonth; day++) {
       const date = new Date(currentYear, currentMonth, day);
       const dateKey = date.toISOString().slice(0, 10); // YYYY-MM-DD format
-      const formattedDate = date.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric'
+      const formattedDate = date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
       });
 
-      const existingData = dailyCurrentMonthResult.find(item => item.date === dateKey);
+      const existingData = dailyCurrentMonthResult.find(
+        (item) => item.date === dateKey,
+      );
       dailyCurrentMonth.push({
         date: dateKey,
         voice_streams: existingData ? existingData.voice_streams : 0,
-        formatted_date: formattedDate
+        formatted_date: formattedDate,
       });
     }
 
     const response: VoiceStreamStats = {
       total_streams: totalResult[0]?.total_streams || 0,
       current_month_streams: currentMonthResult[0]?.current_month_streams || 0,
-      previous_month_streams: previousMonthResult[0]?.previous_month_streams || 0,
+      previous_month_streams:
+        previousMonthResult[0]?.previous_month_streams || 0,
       monthly_data: last12Months,
-      daily_current_month: dailyCurrentMonth
+      daily_current_month: dailyCurrentMonth,
     };
 
     res.json(response);
@@ -165,7 +172,8 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
     console.error("Error fetching voice streams analytics:", error);
     res.status(500).json({
       error: "Failed to fetch voice streams analytics",
-      details: process.env.NODE_ENV === "development" ? error.message : undefined
+      details:
+        process.env.NODE_ENV === "development" ? error.message : undefined,
     });
   }
 };

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -19,8 +19,8 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
   try {
     // Get branch filter from middleware
     const branchFilter = (req as any).branchFilter;
-    const branchFilterCondition = branchFilter 
-      ? `AND ldbu.branch_id = '${branchFilter.value}'` 
+    const branchFilterCondition = branchFilter
+      ? `AND ldbu.branch_id = '${branchFilter.value}'`
       : '';
 
     // Get total voice streams count
@@ -40,8 +40,8 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
       LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
       LEFT JOIN branches b ON b.id = ldbu.branch_id
-      WHERE YEAR(r.start_time) = YEAR(CURDATE()) 
-        AND MONTH(r.start_time) = MONTH(CURDATE()) 
+      WHERE YEAR(r.start_time) = YEAR(CURDATE())
+        AND MONTH(r.start_time) = MONTH(CURDATE())
         ${branchFilterCondition}
     `;
 
@@ -61,8 +61,7 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
     const monthlyQuery = `
       SELECT
         DATE_FORMAT(r.start_time, '%Y-%m') as month,
-        COUNT(*) as voice_streams,
-        DATE_FORMAT(r.start_time, '%b %Y') as formatted_month
+        COUNT(*) as voice_streams
       FROM recordings r
       LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
       LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
@@ -92,11 +91,11 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       const date = new Date();
       date.setMonth(date.getMonth() - i);
       const monthKey = date.toISOString().slice(0, 7); // YYYY-MM format
-      const formattedMonth = date.toLocaleDateString('en-US', { 
-        month: 'short', 
-        year: 'numeric' 
+      const formattedMonth = date.toLocaleDateString('en-US', {
+        month: 'short',
+        year: 'numeric'
       });
-      
+
       const existingData = monthlyResult.find(item => item.month === monthKey);
       last12Months.push({
         month: monthKey,
@@ -115,7 +114,7 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
     res.json(response);
   } catch (error) {
     console.error("Error fetching voice streams analytics:", error);
-    res.status(500).json({ 
+    res.status(500).json({
       error: "Failed to fetch voice streams analytics",
       details: process.env.NODE_ENV === "development" ? error.message : undefined
     });

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -129,11 +129,35 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       });
     }
 
+    // Generate daily data for current month (fill missing days with 0)
+    const currentDate = new Date();
+    const currentYear = currentDate.getFullYear();
+    const currentMonth = currentDate.getMonth();
+    const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+
+    const dailyCurrentMonth: VoiceStreamDailyData[] = [];
+    for (let day = 1; day <= daysInMonth; day++) {
+      const date = new Date(currentYear, currentMonth, day);
+      const dateKey = date.toISOString().slice(0, 10); // YYYY-MM-DD format
+      const formattedDate = date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric'
+      });
+
+      const existingData = dailyCurrentMonthResult.find(item => item.date === dateKey);
+      dailyCurrentMonth.push({
+        date: dateKey,
+        voice_streams: existingData ? existingData.voice_streams : 0,
+        formatted_date: formattedDate
+      });
+    }
+
     const response: VoiceStreamStats = {
       total_streams: totalResult[0]?.total_streams || 0,
       current_month_streams: currentMonthResult[0]?.current_month_streams || 0,
       previous_month_streams: previousMonthResult[0]?.previous_month_streams || 0,
-      monthly_data: last12Months
+      monthly_data: last12Months,
+      daily_current_month: dailyCurrentMonth
     };
 
     res.json(response);

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -1,0 +1,123 @@
+import { RequestHandler } from "express";
+import { executeQuery } from "../config/database";
+
+interface VoiceStreamMonthlyData {
+  month: string;
+  voice_streams: number;
+  formatted_month: string;
+}
+
+interface VoiceStreamStats {
+  total_streams: number;
+  current_month_streams: number;
+  previous_month_streams: number;
+  monthly_data: VoiceStreamMonthlyData[];
+}
+
+// Get voice streams analytics for branch users
+export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
+  try {
+    // Get branch filter from middleware
+    const branchFilter = (req as any).branchFilter;
+    const branchFilterCondition = branchFilter 
+      ? `AND ldbu.branch_id = '${branchFilter.value}'` 
+      : '';
+
+    // Get total voice streams count
+    const totalQuery = `
+      SELECT COUNT(*) as total_streams
+      FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
+      WHERE 1=1 ${branchFilterCondition}
+    `;
+
+    // Get current month voice streams
+    const currentMonthQuery = `
+      SELECT COUNT(*) as current_month_streams
+      FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
+      WHERE YEAR(r.start_time) = YEAR(CURDATE()) 
+        AND MONTH(r.start_time) = MONTH(CURDATE()) 
+        ${branchFilterCondition}
+    `;
+
+    // Get previous month voice streams
+    const previousMonthQuery = `
+      SELECT COUNT(*) as previous_month_streams
+      FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
+      WHERE YEAR(r.start_time) = YEAR(DATE_SUB(CURDATE(), INTERVAL 1 MONTH))
+        AND MONTH(r.start_time) = MONTH(DATE_SUB(CURDATE(), INTERVAL 1 MONTH))
+        ${branchFilterCondition}
+    `;
+
+    // Get monthly voice streams for last 12 months
+    const monthlyQuery = `
+      SELECT
+        DATE_FORMAT(r.start_time, '%Y-%m') as month,
+        COUNT(*) as voice_streams,
+        DATE_FORMAT(r.start_time, '%b %Y') as formatted_month
+      FROM recordings r
+      LEFT JOIN devices d ON d.device_mac = r.mac_address OR d.ip_address = r.ip_address
+      LEFT JOIN link_device_branch_user ldbu ON ldbu.device_id = d.id
+      LEFT JOIN branches b ON b.id = ldbu.branch_id
+      WHERE r.start_time >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
+        ${branchFilterCondition}
+      GROUP BY DATE_FORMAT(r.start_time, '%Y-%m')
+      ORDER BY month ASC
+    `;
+
+    // Execute all queries in parallel
+    const [
+      totalResult,
+      currentMonthResult,
+      previousMonthResult,
+      monthlyResult
+    ] = await Promise.all([
+      executeQuery<{ total_streams: number }>(totalQuery),
+      executeQuery<{ current_month_streams: number }>(currentMonthQuery),
+      executeQuery<{ previous_month_streams: number }>(previousMonthQuery),
+      executeQuery<VoiceStreamMonthlyData>(monthlyQuery)
+    ]);
+
+    // Generate last 12 months array to fill missing months with 0
+    const last12Months = [];
+    for (let i = 11; i >= 0; i--) {
+      const date = new Date();
+      date.setMonth(date.getMonth() - i);
+      const monthKey = date.toISOString().slice(0, 7); // YYYY-MM format
+      const formattedMonth = date.toLocaleDateString('en-US', { 
+        month: 'short', 
+        year: 'numeric' 
+      });
+      
+      const existingData = monthlyResult.find(item => item.month === monthKey);
+      last12Months.push({
+        month: monthKey,
+        voice_streams: existingData ? existingData.voice_streams : 0,
+        formatted_month: formattedMonth
+      });
+    }
+
+    const response: VoiceStreamStats = {
+      total_streams: totalResult[0]?.total_streams || 0,
+      current_month_streams: currentMonthResult[0]?.current_month_streams || 0,
+      previous_month_streams: previousMonthResult[0]?.previous_month_streams || 0,
+      monthly_data: last12Months
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error("Error fetching voice streams analytics:", error);
+    res.status(500).json({ 
+      error: "Failed to fetch voice streams analytics",
+      details: process.env.NODE_ENV === "development" ? error.message : undefined
+    });
+  }
+};

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -81,7 +81,7 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       executeQuery<{ total_streams: number }>(totalQuery),
       executeQuery<{ current_month_streams: number }>(currentMonthQuery),
       executeQuery<{ previous_month_streams: number }>(previousMonthQuery),
-      executeQuery<VoiceStreamMonthlyData>(monthlyQuery)
+      executeQuery<{ month: string; voice_streams: number }>(monthlyQuery)
     ]);
 
     // Generate last 12 months array to fill missing months with 0

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -4,7 +4,6 @@ import { executeQuery } from "../config/database";
 interface VoiceStreamMonthlyData {
   month: string;
   voice_streams: number;
-  formatted_month: string;
 }
 
 interface VoiceStreamStats {

--- a/server/routes/voice-streams-analytics.ts
+++ b/server/routes/voice-streams-analytics.ts
@@ -100,12 +100,14 @@ export const getVoiceStreamsAnalytics: RequestHandler = async (req, res) => {
       totalResult,
       currentMonthResult,
       previousMonthResult,
-      monthlyResult
+      monthlyResult,
+      dailyCurrentMonthResult
     ] = await Promise.all([
       executeQuery<{ total_streams: number }>(totalQuery),
       executeQuery<{ current_month_streams: number }>(currentMonthQuery),
       executeQuery<{ previous_month_streams: number }>(previousMonthQuery),
-      executeQuery<{ month: string; voice_streams: number }>(monthlyQuery)
+      executeQuery<{ month: string; voice_streams: number }>(monthlyQuery),
+      executeQuery<{ date: string; voice_streams: number }>(dailyCurrentMonthQuery)
     ]);
 
     // Generate last 12 months array to fill missing months with 0


### PR DESCRIPTION
## Purpose

The user requested analytics functionality for logged-in users to view voice stream data for their device. They specifically wanted:
1. Voice streams data displayed per month over time
2. Voice streams data for the current month
3. Both charts displayed side by side for easy comparison

## Code changes

- **Added new component `BranchVoiceStreamsAnalytics.tsx`**: Complete analytics dashboard with responsive design featuring:
  - Stats cards showing total streams, current month streams, and monthly growth percentage
  - Side-by-side layout with monthly bar chart and daily area chart for current month
  - Loading states, error handling, and custom tooltips
  - Gradient styling and responsive grid layout

- **Added new API route `voice-streams-analytics.ts`**: Backend endpoint that:
  - Queries recordings table with proper branch filtering for non-admin users
  - Calculates total, current month, and previous month voice stream counts
  - Generates monthly data for last 12 months (filling missing months with 0)
  - Generates daily data for current month (filling missing days with 0)
  - Handles parallel query execution for performance

- **Updated heartbeat route**: Improved query performance and added fallback handling for database query failures

The implementation provides comprehensive voice stream analytics with both temporal views (monthly trends and daily current month activity) displayed in an intuitive side-by-side layout.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/53cee87719b84699a8ac0f639e916880/neon-nest)

👀 [Preview Link](https://53cee87719b84699a8ac0f639e916880-neon-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>53cee87719b84699a8ac0f639e916880</projectId>-->
<!--<branchName>neon-nest</branchName>-->