### PR TITLE
Update user interface to show branch names and hide admin features

### DIFF
--- a/client/components/ConversationAnalytics.tsx
+++ b/client/components/ConversationAnalytics.tsx
@@ -531,17 +531,19 @@ export function ConversationAnalytics() {
             <div className="text-sm font-medium">By Branch</div>
           </button>
 
-          <button
-            onClick={() => setActiveChart("city")}
-            className={`p-4 rounded-lg border-2 transition-all ${
-              activeChart === "city"
-                ? "border-green-500 bg-green-50 text-green-700"
-                : "border-gray-200 hover:border-gray-300 text-gray-600"
-            }`}
-          >
-            <MapPin className="h-5 w-5 mx-auto mb-2" />
-            <div className="text-sm font-medium">By City</div>
-          </button>
+          {isAdmin() && (
+            <button
+              onClick={() => setActiveChart("city")}
+              className={`p-4 rounded-lg border-2 transition-all ${
+                activeChart === "city"
+                  ? "border-green-500 bg-green-50 text-green-700"
+                  : "border-gray-200 hover:border-gray-300 text-gray-600"
+              }`}
+            >
+              <MapPin className="h-5 w-5 mx-auto mb-2" />
+              <div className="text-sm font-medium">By City</div>
+            </button>
+          )}
 
           <button
             onClick={() => setActiveChart("daily")}

--- a/client/components/ConversationAnalytics.tsx
+++ b/client/components/ConversationAnalytics.tsx
@@ -469,8 +469,6 @@ export function ConversationAnalytics() {
     return item?.unique_cnic_count || 0;
   };
 
-
-
   if (loading) {
     return (
       <div className="bg-white rounded-lg shadow p-6">
@@ -590,15 +588,19 @@ export function ConversationAnalytics() {
                         className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       >
                         {availableBranches.map((branch) => (
-                          <option key={branch.branch_id} value={branch.branch_id}>
+                          <option
+                            key={branch.branch_id}
+                            value={branch.branch_id}
+                          >
                             {branch.branch_name}
                           </option>
                         ))}
                       </select>
                     ) : (
                       <span className="text-sm font-medium text-gray-700">
-                        {availableBranches.find((b) => b.branch_id === selectedBranch)
-                          ?.branch_name || "Your Branch"}
+                        {availableBranches.find(
+                          (b) => b.branch_id === selectedBranch,
+                        )?.branch_name || "Your Branch"}
                       </span>
                     )}
                   </div>
@@ -705,8 +707,8 @@ export function ConversationAnalytics() {
                       </select>
                     ) : (
                       <span className="text-sm font-medium text-gray-700">
-                        {availableCities.find((c) => c.city === selectedCity)?.city ||
-                          "Your City"}
+                        {availableCities.find((c) => c.city === selectedCity)
+                          ?.city || "Your City"}
                       </span>
                     )}
                   </div>
@@ -809,7 +811,10 @@ export function ConversationAnalytics() {
                         className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
                       >
                         {availableBranches.map((branch) => (
-                          <option key={branch.branch_id} value={branch.branch_id}>
+                          <option
+                            key={branch.branch_id}
+                            value={branch.branch_id}
+                          >
                             {branch.branch_name}
                           </option>
                         ))}

--- a/client/components/ConversationAnalytics.tsx
+++ b/client/components/ConversationAnalytics.tsx
@@ -581,17 +581,24 @@ export function ConversationAnalytics() {
                 {availableBranches.length > 0 && (
                   <div className="flex items-center space-x-2">
                     <Building2 className="h-4 w-4 text-gray-500" />
-                    <select
-                      value={selectedBranch}
-                      onChange={(e) => setSelectedBranch(e.target.value)}
-                      className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    >
-                      {availableBranches.map((branch) => (
-                        <option key={branch.branch_id} value={branch.branch_id}>
-                          {branch.branch_name}
-                        </option>
-                      ))}
-                    </select>
+                    {isAdmin() ? (
+                      <select
+                        value={selectedBranch}
+                        onChange={(e) => setSelectedBranch(e.target.value)}
+                        className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      >
+                        {availableBranches.map((branch) => (
+                          <option key={branch.branch_id} value={branch.branch_id}>
+                            {branch.branch_name}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span className="text-sm font-medium text-gray-700">
+                        {availableBranches.find((b) => b.branch_id === selectedBranch)
+                          ?.branch_name || "Your Branch"}
+                      </span>
+                    )}
                   </div>
                 )}
               </div>
@@ -682,17 +689,24 @@ export function ConversationAnalytics() {
                 {availableCities.length > 0 && (
                   <div className="flex items-center space-x-2">
                     <MapPin className="h-4 w-4 text-gray-500" />
-                    <select
-                      value={selectedCity}
-                      onChange={(e) => setSelectedCity(e.target.value)}
-                      className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
-                    >
-                      {availableCities.map((city) => (
-                        <option key={city.city} value={city.city}>
-                          {city.city}
-                        </option>
-                      ))}
-                    </select>
+                    {isAdmin() ? (
+                      <select
+                        value={selectedCity}
+                        onChange={(e) => setSelectedCity(e.target.value)}
+                        className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                      >
+                        {availableCities.map((city) => (
+                          <option key={city.city} value={city.city}>
+                            {city.city}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span className="text-sm font-medium text-gray-700">
+                        {availableCities.find((c) => c.city === selectedCity)?.city ||
+                          "Your City"}
+                      </span>
+                    )}
                   </div>
                 )}
               </div>
@@ -784,19 +798,27 @@ export function ConversationAnalytics() {
                 {availableBranches.length > 0 && (
                   <div className="flex items-center space-x-2">
                     <Building2 className="h-4 w-4 text-gray-500" />
-                    <select
-                      value={selectedBranchForDaily}
-                      onChange={(e) =>
-                        setSelectedBranchForDaily(e.target.value)
-                      }
-                      className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
-                    >
-                      {availableBranches.map((branch) => (
-                        <option key={branch.branch_id} value={branch.branch_id}>
-                          {branch.branch_name}
-                        </option>
-                      ))}
-                    </select>
+                    {isAdmin() ? (
+                      <select
+                        value={selectedBranchForDaily}
+                        onChange={(e) =>
+                          setSelectedBranchForDaily(e.target.value)
+                        }
+                        className="border border-gray-300 rounded-md px-3 py-1 text-sm bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+                      >
+                        {availableBranches.map((branch) => (
+                          <option key={branch.branch_id} value={branch.branch_id}>
+                            {branch.branch_name}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span className="text-sm font-medium text-gray-700">
+                        {availableBranches.find(
+                          (b) => b.branch_id === selectedBranchForDaily,
+                        )?.branch_name || "Your Branch"}
+                      </span>
+                    )}
                   </div>
                 )}
               </div>

--- a/client/components/ConversationAnalytics.tsx
+++ b/client/components/ConversationAnalytics.tsx
@@ -340,10 +340,8 @@ export function ConversationAnalytics() {
   };
 
   useEffect(() => {
-    if (isAdmin()) {
-      fetchAnalyticsData();
-    }
-  }, [isAdmin]);
+    fetchAnalyticsData();
+  }, []);
 
   useEffect(() => {
     if (selectedBranch && activeChart === "branch") {
@@ -471,7 +469,7 @@ export function ConversationAnalytics() {
     return item?.unique_cnic_count || 0;
   };
 
-  if (!isAdmin()) return null;
+
 
   if (loading) {
     return (

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -207,11 +207,11 @@ export function Header() {
           {/* User Info */}
           <div className="flex items-center space-x-3">
             <div className="flex items-center space-x-2 text-sm text-gray-600">
-              {(user.branch_name || user.branch_city) && (
+              {(user.branch_address || user.branch_name || user.branch_city) && (
                 <div className="flex items-center space-x-1">
                   <Building2 className="h-4 w-4" />
                   <span>
-                    Branch: {isAdmin() ? user.branch_city : (user.branch_name || user.branch_city)}
+                    Branch: {isAdmin() ? user.branch_city : (user.branch_address || user.branch_name || user.branch_city)}
                   </span>
                 </div>
               )}

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -207,11 +207,18 @@ export function Header() {
           {/* User Info */}
           <div className="flex items-center space-x-3">
             <div className="flex items-center space-x-2 text-sm text-gray-600">
-              {(user.branch_address || user.branch_name || user.branch_city) && (
+              {(user.branch_address ||
+                user.branch_name ||
+                user.branch_city) && (
                 <div className="flex items-center space-x-1">
                   <Building2 className="h-4 w-4" />
                   <span>
-                    Branch: {isAdmin() ? user.branch_city : (user.branch_address || user.branch_name || user.branch_city)}
+                    Branch:{" "}
+                    {isAdmin()
+                      ? user.branch_city
+                      : user.branch_address ||
+                        user.branch_name ||
+                        user.branch_city}
                   </span>
                 </div>
               )}

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -207,10 +207,12 @@ export function Header() {
           {/* User Info */}
           <div className="flex items-center space-x-3">
             <div className="flex items-center space-x-2 text-sm text-gray-600">
-              {user.branch_city && (
+              {(user.branch_name || user.branch_city) && (
                 <div className="flex items-center space-x-1">
                   <Building2 className="h-4 w-4" />
-                  <span>Branch: {user.branch_city}</span>
+                  <span>
+                    Branch: {isAdmin() ? user.branch_city : (user.branch_name || user.branch_city)}
+                  </span>
                 </div>
               )}
             </div>

--- a/client/contexts/AuthContext.tsx
+++ b/client/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ export interface User {
   role: "admin" | "manager" | "user";
   branch_id: string | null;
   branch_city: string | null;
+  branch_name: string | null;
   emp_name: string | null;
   phone_no: string | null;
   email_id: string | null;

--- a/client/contexts/AuthContext.tsx
+++ b/client/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ export interface User {
   branch_id: string | null;
   branch_city: string | null;
   branch_name: string | null;
+  branch_address: string | null;
   emp_name: string | null;
   phone_no: string | null;
   email_id: string | null;

--- a/server/routes/users-db.ts
+++ b/server/routes/users-db.ts
@@ -299,11 +299,12 @@ export const loginUser: RequestHandler = async (req, res) => {
 
     // Get user by username with branch info from link table
     const users = await executeQuery<
-      User & { branch_id: string | null; branch_city: string | null }
+      User & { branch_id: string | null; branch_city: string | null; branch_name: string | null }
     >(
       `SELECT u.*,
               ldbu.branch_id as branch_id,
-              b.branch_city as branch_city
+              b.branch_city as branch_city,
+              b.branch_name as branch_name
        FROM users u
        LEFT JOIN link_device_branch_user ldbu ON ldbu.user_id COLLATE utf8mb4_0900_ai_ci = u.uuid COLLATE utf8mb4_0900_ai_ci
        LEFT JOIN branches b ON b.id COLLATE utf8mb4_0900_ai_ci = ldbu.branch_id COLLATE utf8mb4_0900_ai_ci
@@ -336,6 +337,7 @@ export const loginUser: RequestHandler = async (req, res) => {
       role: user.role,
       branch_id: user.branch_id,
       branch_city: user.branch_city,
+      branch_name: user.branch_name,
       emp_name: user.emp_name,
       phone_no: user.phone_no,
       email_id: user.email_id,

--- a/server/routes/users-db.ts
+++ b/server/routes/users-db.ts
@@ -29,6 +29,7 @@ export interface UserSession {
   branch_id: string | null;
   branch_city: string | null;
   branch_name: string | null;
+  branch_address: string | null;
   emp_name: string | null;
   phone_no: string | null;
   email_id: string | null;
@@ -300,12 +301,13 @@ export const loginUser: RequestHandler = async (req, res) => {
 
     // Get user by username with branch info from link table
     const users = await executeQuery<
-      User & { branch_id: string | null; branch_city: string | null; branch_name: string | null }
+      User & { branch_id: string | null; branch_city: string | null; branch_name: string | null; branch_address: string | null }
     >(
       `SELECT u.*,
               ldbu.branch_id as branch_id,
               b.branch_city as branch_city,
-              b.branch_name as branch_name
+              b.branch_name as branch_name,
+              b.branch_address as branch_address
        FROM users u
        LEFT JOIN link_device_branch_user ldbu ON ldbu.user_id COLLATE utf8mb4_0900_ai_ci = u.uuid COLLATE utf8mb4_0900_ai_ci
        LEFT JOIN branches b ON b.id COLLATE utf8mb4_0900_ai_ci = ldbu.branch_id COLLATE utf8mb4_0900_ai_ci
@@ -339,6 +341,7 @@ export const loginUser: RequestHandler = async (req, res) => {
       branch_id: user.branch_id,
       branch_city: user.branch_city,
       branch_name: user.branch_name,
+      branch_address: user.branch_address,
       emp_name: user.emp_name,
       phone_no: user.phone_no,
       email_id: user.email_id,

--- a/server/routes/users-db.ts
+++ b/server/routes/users-db.ts
@@ -28,6 +28,7 @@ export interface UserSession {
   role: "admin" | "manager" | "user";
   branch_id: string | null;
   branch_city: string | null;
+  branch_name: string | null;
   emp_name: string | null;
   phone_no: string | null;
   email_id: string | null;

--- a/server/routes/users-db.ts
+++ b/server/routes/users-db.ts
@@ -301,7 +301,12 @@ export const loginUser: RequestHandler = async (req, res) => {
 
     // Get user by username with branch info from link table
     const users = await executeQuery<
-      User & { branch_id: string | null; branch_city: string | null; branch_name: string | null; branch_address: string | null }
+      User & {
+        branch_id: string | null;
+        branch_city: string | null;
+        branch_name: string | null;
+        branch_address: string | null;
+      }
     >(
       `SELECT u.*,
               ldbu.branch_id as branch_id,


### PR DESCRIPTION
## Purpose

The user requested several UI improvements for non-admin users:
- Replace branch dropdown with static branch name display for regular users
- Hide the "By City" analytics tab for non-admin users  
- Show full branch name instead of city name in the top-right header
- Ensure complete branch names are displayed rather than abbreviated versions

## Code changes

**ConversationAnalytics.tsx:**
- Removed admin-only restriction on component access and data fetching
- Wrapped "By City" tab button with `isAdmin()` conditional to hide from regular users
- Replaced branch/city dropdowns with static text displays for non-admin users
- Added conditional rendering to show dropdowns only for admins, static labels for users

**Header.tsx:**
- Updated branch display logic to show `branch_address` or `branch_name` for users, `branch_city` for admins
- Enhanced fallback chain to ensure full branch information is displayed

**AuthContext.tsx & users-db.ts:**
- Added `branch_name` and `branch_address` fields to User interface and UserSession
- Updated login query to fetch additional branch details from database
- Extended user session data to include complete branch information

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b903397df90d44e9ba11a169d0967026/orbit-realm)

👀 [Preview Link](https://b903397df90d44e9ba11a169d0967026-orbit-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b903397df90d44e9ba11a169d0967026</projectId>-->
<!--<branchName>orbit-realm</branchName>-->